### PR TITLE
Add control telemetry, log stream, setpoint override and fix debug sl…

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,9 @@ from lib.ninedof_receiver import init_imu_receiver
 from lib.axis_config_sender import send_axis_config
 from lib.resource_receiver import init_resource_receiver
 from lib.json_data_handler import JSONDataHandler
+from lib.control_telemetry import init_control_telemetry
+from lib.log_udp_receiver import init_log_stream
+from lib.setpoint_override import init_setpoint_override
 import atexit
 import os
 
@@ -75,6 +78,16 @@ app.config["IP_CAMERA"] = init_ip_camera(
 )
 # Start background resource monitor receiver (UDP port 12346)
 app.config["RESOURCE"] = init_resource_receiver(port=12346)
+app.config["BITMASK"].set_resource_monitor(app.config["RESOURCE"])
+
+# Initialize setpoint override client (UDP port 5007)
+app.config["SETPOINT_OVERRIDE"] = init_setpoint_override(resource_monitor=app.config["RESOURCE"])
+
+# Start control loop telemetry receiver (UDP port 5005)
+app.config["CONTROL_TELEM"] = init_control_telemetry(port=5005)
+
+# Start Zephyr log stream receiver (UDP port 5006)
+app.config["LOG_STREAM"] = init_log_stream(port=5006)
 
 register_routes(app)
 camera = init_camera()
@@ -92,6 +105,12 @@ def _shutdown():
     if ip_cam: ip_cam.stop()
     resource = app.config.get("RESOURCE")
     if resource: resource.stop()
+    ctrl_telem = app.config.get("CONTROL_TELEM")
+    if ctrl_telem: ctrl_telem.stop()
+    log_stream = app.config.get("LOG_STREAM")
+    if log_stream: log_stream.stop()
+    sp_override = app.config.get("SETPOINT_OVERRIDE")
+    if sp_override: sp_override.close()
 atexit.register(_shutdown)
 
 def run_dashboard_server():

--- a/lib/bitmask.py
+++ b/lib/bitmask.py
@@ -1,8 +1,14 @@
 # lib/bitmask.py
-import socket, struct, threading, time, zlib
+import struct
+import threading
+import time
 from dataclasses import dataclass, asdict
 
-NUCLEO_HOST = "192.168.1.100" # default NUCLEO IP
+from lib.crc import crc32_ieee
+from lib.net_transport import DEFAULT_ROV_HOST, UdpSender, next_sequence
+from typing import Optional
+
+NUCLEO_HOST = DEFAULT_ROV_HOST  # default NUCLEO IP
 NUCLEO_PORT = 12345
 DEFAULT_RATE_HZ = 20.0      # send frequency
 
@@ -35,11 +41,11 @@ def encode_payload(cmd: Command) -> int:
 
 def build_packet(seq: int, payload_u64: int) -> bytes:
     header = struct.pack("!IQ", seq & 0xFFFFFFFF, payload_u64 & 0xFFFFFFFFFFFFFFFF)
-    crc = zlib.crc32(header) & 0xFFFFFFFF
-    return header + struct.pack("!I", crc)
+    crc = crc32_ieee(header)
+    return header + struct.pack("!I", crc & 0xFFFFFFFF)
 
 class BitmaskClient:
-    def __init__(self, host=NUCLEO_HOST, port=NUCLEO_PORT, rate_hz=DEFAULT_RATE_HZ):
+    def __init__(self, host=NUCLEO_HOST, port=NUCLEO_PORT, rate_hz=DEFAULT_RATE_HZ, watchdog_timeout=0.75):
         self.host, self.port = host, port
         self.period = 1.0 / float(rate_hz) if rate_hz > 0 else 0.0
         self._cmd = Command()
@@ -47,20 +53,39 @@ class BitmaskClient:
         self._lock = threading.Lock()
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, name="BitmaskSender", daemon=True)
-        self._sock = None
+        self._watchdog_thread = threading.Thread(target=self._watchdog_loop, name="BitmaskWatchdog", daemon=True)
+        self._sender: Optional[UdpSender] = None
+        self._resource_monitor = None
+
+        # Uplink health/state
+        self._status_lock = threading.Lock()
+        self._last_packet: bytes | None = None
+        self._last_send_time = 0.0
+        self._last_ack_time = 0.0
+        self._last_ack_count = None
+        self._watchdog_timeout = watchdog_timeout
+        self._watchdog_resends = 0
+        self._last_command_snapshot: dict | None = None
 
     def start(self):
-        if self._thread.is_alive(): return
-        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        if self._thread.is_alive():
+            return
+        self._sender = UdpSender(self.host, self.port)
+        self._stop.clear()
+        with self._status_lock:
+            self._last_ack_time = time.monotonic()
         self._thread.start()
+        self._watchdog_thread.start()
 
     def stop(self):
         self._stop.set()
-        if self._thread.is_alive(): self._thread.join(timeout=1.0)
-        if self._sock:
-            try: self._sock.close()
-            except: pass
-            self._sock = None
+        if self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+        if self._watchdog_thread.is_alive():
+            self._watchdog_thread.join(timeout=1.0)
+        if self._sender:
+            self._sender.close()
+            self._sender = None
 
     def set_command(self, **kwargs):
         with self._lock:
@@ -71,6 +96,24 @@ class BitmaskClient:
     def get_command(self) -> dict:
         with self._lock:
             return asdict(self._cmd) | {"sequence": self._seq}
+
+    def set_resource_monitor(self, monitor) -> None:
+        self._resource_monitor = monitor
+
+    def get_uplink_status(self) -> dict:
+        with self._status_lock:
+            now = time.monotonic()
+            send_age = None if self._last_send_time == 0 else max(0.0, now - self._last_send_time) * 1000.0
+            ack_age = None if self._last_ack_time == 0 else max(0.0, now - self._last_ack_time) * 1000.0
+            return {
+                "sequence": self._seq,
+                "last_send_age_ms": send_age,
+                "last_ack_age_ms": ack_age,
+                "last_ack_count": self._last_ack_count,
+                "watchdog_timeout": self._watchdog_timeout,
+                "watchdog_resends": self._watchdog_resends,
+                "last_command": self._last_command_snapshot or {},
+            }
 
     # convenience: set from normalized axes
     def set_from_axes(self, surge=0.0, sway=0.0, heave=0.0, roll=0.0, pitch=0.0, yaw=0.0,
@@ -87,12 +130,46 @@ class BitmaskClient:
             with self._lock:
                 payload = encode_payload(self._cmd)
                 pkt = build_packet(self._seq, payload)
-                self._seq = (self._seq + 1) & 0xFFFFFFFF
-            try:
-                self._sock.sendto(pkt, (self.host, self.port))
-            except Exception:
-                pass
+                self._seq = next_sequence(self._seq)
+                command_snapshot = asdict(self._cmd)
+            sender = self._sender
+            if sender:
+                try:
+                    sender.send(pkt)
+                except Exception:
+                    pass
+            with self._status_lock:
+                self._last_packet = pkt
+                self._last_send_time = time.monotonic()
+                self._last_command_snapshot = command_snapshot
             time.sleep(self.period)
+
+    def _watchdog_loop(self):
+        while not self._stop.is_set():
+            time.sleep(0.1)
+            monitor = self._resource_monitor
+            if monitor is None:
+                continue
+            counters = getattr(monitor, "get_udp_counters", None)
+            if counters is None:
+                continue
+            udp_rx_count, _errors = counters()
+            now = time.monotonic()
+            with self._status_lock:
+                if udp_rx_count != self._last_ack_count:
+                    self._last_ack_count = udp_rx_count
+                    self._last_ack_time = now
+                    continue
+                # No new acks yet
+                if self._last_packet and (now - self._last_ack_time) > self._watchdog_timeout:
+                    sender = self._sender
+                    if sender:
+                        try:
+                            sender.send(self._last_packet)
+                            self._watchdog_resends += 1
+                        except Exception:
+                            pass
+                    self._last_ack_time = now
 
 # simple initializer
 def init_bitmask(rate_hz=DEFAULT_RATE_HZ, host=NUCLEO_HOST, port=NUCLEO_PORT) -> BitmaskClient:

--- a/lib/control_telemetry.py
+++ b/lib/control_telemetry.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Control loop telemetry receiver.
+
+Consumes the packed struct emitted by ``control_telemetry.c`` and exposes the
+latest setpoint/output/error triplets for each axis so the debug UI can render
+10 Hz charts. Packets are structured as::
+
+    sequence (u32 big-endian)
+    setpoint[6] (float32 little-endian, surge..yaw)
+    output[6]   (float32 little-endian)
+    error[6]    (float32 little-endian)
+    crc32 (u32 big-endian)
+
+The CRC covers the bytes up to but excluding the CRC field.
+"""
+
+import json
+import struct
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from typing import Deque, Dict, List
+
+from lib.crc import crc32_ieee
+from lib.json_data_handler import JSONDataHandler
+from lib.net_transport import UdpConfig, UdpListener
+
+CONTROL_TELEM_PORT = 5005
+AXES = ["surge", "sway", "heave", "roll", "pitch", "yaw"]
+FLOAT_COUNT = len(AXES) * 3
+PACKET_SIZE = 4 + FLOAT_COUNT * 4 + 4
+HISTORY_CAPACITY = 240  # 24 seconds @ 10 Hz
+LOG_DIR = Path("logs")
+CONTROL_LOG = LOG_DIR / "control_telemetry.ndjson"
+
+
+class ControlTelemetryReceiver:
+    def __init__(self, host: str = "0.0.0.0", port: int = CONTROL_TELEM_PORT, data_handler: JSONDataHandler | None = None):
+        self.host = host
+        self.port = port
+        self.data_handler = data_handler or JSONDataHandler()
+        self._listener: UdpListener | None = None
+        self._lock = threading.Lock()
+        self._latest: Dict[str, dict] = {}
+        self._history: Deque[dict] = deque(maxlen=HISTORY_CAPACITY)
+        self._capture_enabled = True
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    def start(self) -> None:
+        if self._listener is not None:
+            return
+        cfg = UdpConfig(host=self.host, port=self.port, broadcast=True, timeout=1.0, recv_buffer=2048)
+        self._listener = UdpListener("ControlTelemetry", cfg, self._handle_packet)
+        self._listener.start()
+        print(f"Control telemetry receiver started on {self.host}:{self.port}")
+
+    def stop(self) -> None:
+        if self._listener:
+            self._listener.stop()
+            self._listener = None
+        print("Control telemetry receiver stopped")
+
+    def enable_capture(self) -> None:
+        self._capture_enabled = True
+
+    def disable_capture(self) -> None:
+        self._capture_enabled = False
+
+    def get_latest(self) -> dict:
+        with self._lock:
+            return self._latest.copy()
+
+    def get_history(self, limit: int = 120) -> List[dict]:
+        """Return up to *limit* most recent telemetry samples."""
+
+        limit = max(1, min(limit, HISTORY_CAPACITY))
+        with self._lock:
+            if not self._history:
+                return []
+            hist_list = list(self._history)
+        return hist_list[-limit:]
+
+    # Internal helpers -------------------------------------------------
+    def _handle_packet(self, data: bytes, addr: tuple[str, int]):
+        if len(data) != PACKET_SIZE:
+            print(f"Control telemetry: invalid packet size from {addr}: {len(data)} bytes (expected {PACKET_SIZE})")
+            return
+        body = data[:-4]
+        crc = struct.unpack("!I", data[-4:])[0]
+        calc = crc32_ieee(body)
+        if calc != crc:
+            print(f"Control telemetry: CRC mismatch (calc=0x{calc:08X}, recv=0x{crc:08X})")
+            return
+        sequence = struct.unpack("!I", body[:4])[0]
+        floats = struct.unpack("<" + "f" * FLOAT_COUNT, body[4:])
+        setpoints = dict(zip(AXES, floats[0:6]))
+        outputs = dict(zip(AXES, floats[6:12]))
+        errors = dict(zip(AXES, floats[12:18]))
+        snapshot = {
+            "sequence": sequence,
+            "timestamp": time.time(),
+            "setpoint": {k: round(v, 4) for k, v in setpoints.items()},
+            "output": {k: round(v, 4) for k, v in outputs.items()},
+            "error": {k: round(v, 4) for k, v in errors.items()},
+        }
+        with self._lock:
+            self._latest = snapshot
+            self._history.append(snapshot)
+        try:
+            self.data_handler.update_data({"control_telemetry": snapshot})
+        except Exception as exc:
+            print(f"Control telemetry: failed to persist snapshot: {exc}")
+        if self._capture_enabled:
+            self._append_log(snapshot)
+
+    def _append_log(self, snapshot: dict) -> None:
+        try:
+            with CONTROL_LOG.open("a", encoding="utf-8") as fp:
+                fp.write(json.dumps(snapshot) + "\n")
+        except OSError as exc:
+            print(f"Control telemetry: failed to log snapshot: {exc}")
+
+
+def init_control_telemetry(host: str = "0.0.0.0", port: int = CONTROL_TELEM_PORT, data_handler: JSONDataHandler | None = None) -> ControlTelemetryReceiver:
+    receiver = ControlTelemetryReceiver(host=host, port=port, data_handler=data_handler)
+    receiver.start()
+    return receiver

--- a/lib/crc.py
+++ b/lib/crc.py
@@ -1,0 +1,107 @@
+"""CRC utilities shared across topside networking modules.
+
+Implements IEEE 802.3 CRC-32 (polynomial 0x04C11DB7) in the same bitwise
+orientation used by Ethernet, Zephyr, and the embedded `crc32_calc()` helper.
+This module exposes both convenience functions and a small streaming helper so
+callers can avoid re-implementing the lookup-table each time they need to
+checksum a packet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+# Ethernet / IEEE 802.3 parameters
+_POLY_REFLECTED = 0xEDB88320
+_INIT = 0xFFFFFFFF
+_XOROUT = 0xFFFFFFFF
+
+# Lazily-built lookup table so import cost stays low for modules that do not end
+# up hashing any payloads.
+_crc_table: Optional[list[int]] = None
+
+
+def _ensure_table() -> list[int]:
+    global _crc_table
+    if _crc_table is not None:
+        return _crc_table
+    table = []
+    for byte in range(256):
+        crc = byte
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ _POLY_REFLECTED
+            else:
+                crc >>= 1
+        table.append(crc & 0xFFFFFFFF)
+    _crc_table = table
+    return table
+
+
+def crc32_ieee(data: bytes, initial: int = _INIT) -> int:
+    """Return the IEEE 802.3 CRC-32 of *data*.
+
+    Args:
+        data: Raw bytes to checksum.
+        initial: Optional starting value allowing streaming CRCs.
+
+    Returns:
+        Unsigned 32-bit checksum with the standard XOR-out applied.
+    """
+
+    table = _ensure_table()
+    crc = initial & 0xFFFFFFFF
+    for byte in data:
+        idx = (crc ^ byte) & 0xFF
+        crc = (crc >> 8) ^ table[idx]
+    return crc ^ _XOROUT
+
+
+def crc32_continue(crc: int, data: bytes) -> int:
+    """Continue a CRC calculation with more data (no XOR-out applied).
+
+    This helper mirrors the `crc32_ieee` implementation but returns the raw
+    internal state so callers can feed multiple chunks before applying the final
+    XOR. Most modules can call :func:`crc32_ieee` directly; this function mainly
+    exists for tooling that needs to build a CRC over segmented payloads.
+    """
+
+    table = _ensure_table()
+    state = crc & 0xFFFFFFFF
+    for byte in data:
+        idx = (state ^ byte) & 0xFF
+        state = (state >> 8) ^ table[idx]
+    return state
+
+
+@dataclass
+class CRC32:
+    """Incremental CRC helper.
+
+    Example::
+
+        crc = CRC32()
+        crc.update(header)
+        crc.update(payload)
+        digest = crc.digest()
+    """
+
+    _state: int = _INIT
+
+    def update(self, data: bytes | bytearray | memoryview) -> None:
+        table = _ensure_table()
+        state = self._state
+        for byte in data:
+            idx = (state ^ byte) & 0xFF
+            state = (state >> 8) ^ table[idx]
+        self._state = state
+
+    def digest(self) -> int:
+        return self._state ^ _XOROUT
+
+    def hexdigest(self) -> str:
+        return f"{self.digest():08x}"
+
+    def reset(self) -> None:
+        self._state = _INIT

--- a/lib/log_udp_receiver.py
+++ b/lib/log_udp_receiver.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Listener for Zephyr's UDP log backend.
+
+The firmware forwards human-readable log lines over UDP broadcast on
+``LOG_UDP_PORT`` (5006). Each datagram is a newline-terminated chunk; there is
+no reply/acknowledgement channel. This module buffers the most recent entries so
+the debug page can show live logs while also writing everything to disk for
+post-mission correlation.
+"""
+
+import json
+import re
+import threading
+import time
+from pathlib import Path
+from typing import List
+
+from lib.net_transport import UdpConfig, UdpListener
+
+LOG_PORT = 5006
+LOG_DIR = Path("logs")
+LOG_FILE = LOG_DIR / "zephyr.log"
+SEVERITY_RE = re.compile(r"^\[(?P<level>[IWRD])\]\s*")
+
+
+class LogStreamReceiver:
+    def __init__(self, host: str = "0.0.0.0", port: int = LOG_PORT, max_entries: int = 500):
+        self.host = host
+        self.port = port
+        self.max_entries = max_entries
+        self._listener: UdpListener | None = None
+        self._buffer: List[dict] = []
+        self._lock = threading.Lock()
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    def start(self) -> None:
+        if self._listener is not None:
+            return
+        cfg = UdpConfig(host=self.host, port=self.port, broadcast=True, timeout=1.0, recv_buffer=2048)
+        self._listener = UdpListener("LogStream", cfg, self._handle_packet)
+        self._listener.start()
+        print(f"Log stream receiver listening on {self.host}:{self.port}")
+
+    def stop(self) -> None:
+        if self._listener:
+            self._listener.stop()
+            self._listener = None
+        print("Log stream receiver stopped")
+
+    def get_recent(self, limit: int = 100) -> List[dict]:
+        with self._lock:
+            return list(self._buffer[-limit:])
+
+    def _handle_packet(self, data: bytes, addr: tuple[str, int]):
+        try:
+            text = data.decode("utf-8", errors="replace").rstrip("\r\n")
+        except Exception as exc:
+            print(f"Log stream: decode error from {addr}: {exc}")
+            return
+        level = "I"
+        match = SEVERITY_RE.match(text)
+        if match:
+            level = match.group("level")
+            text = text[match.end():]
+        entry = {
+            "ts": time.time(),
+            "level": level,
+            "message": text,
+        }
+        with self._lock:
+            self._buffer.append(entry)
+            if len(self._buffer) > self.max_entries:
+                self._buffer = self._buffer[-self.max_entries:]
+        self._append_log(entry)
+
+    def _append_log(self, entry: dict) -> None:
+        try:
+            with LOG_FILE.open("a", encoding="utf-8") as fp:
+                fp.write(json.dumps(entry) + "\n")
+        except OSError as exc:
+            print(f"Log stream: failed to write log: {exc}")
+
+
+def init_log_stream(host: str = "0.0.0.0", port: int = LOG_PORT) -> LogStreamReceiver:
+    receiver = LogStreamReceiver(host=host, port=port)
+    receiver.start()
+    return receiver

--- a/lib/net_transport.py
+++ b/lib/net_transport.py
@@ -1,0 +1,137 @@
+"""Reusable UDP transport helpers for all topside networking modules.
+
+The ROV-side firmware exposes several UDP services (control, telemetry,
+logging, resource monitoring, etc). Instead of letting every feature manage its
+own sockets, this module centralizes the boilerplate: socket creation with
+optional broadcast, listener-thread management, and convenience utilities such
+as monotonically increasing sequence counters.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+DEFAULT_ROV_HOST = "192.168.1.100"
+DEFAULT_BROADCAST = "192.168.1.255"
+BUFFER_SIZE = 4096
+
+Handler = Callable[[bytes, tuple[str, int]], None]
+
+
+def next_sequence(prev: int) -> int:
+    """Return *(prev + 1) mod 2**32*.
+
+    The firmware's `net.c` expects 32-bit unsigned sequence numbers in big
+    endian, so keeping the arithmetic centralized avoids subtle `& 0xFFFFFFFF`
+    mistakes around the codebase.
+    """
+
+    return (prev + 1) & 0xFFFFFFFF
+
+
+@dataclass
+class UdpConfig:
+    host: str = "0.0.0.0"
+    port: int = 0
+    broadcast: bool = False
+    reuse: bool = True
+    recv_buffer: int = BUFFER_SIZE
+    timeout: float = 0.5  # seconds
+
+
+class UdpSocket:
+    """Thin wrapper that configures UDP sockets consistently."""
+
+    def __init__(self, config: UdpConfig):
+        self.config = config
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        if config.reuse:
+            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if config.broadcast:
+            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        self.sock.settimeout(config.timeout)
+        if config.port:
+            self.sock.bind((config.host, config.port))
+
+    def close(self) -> None:
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+class UdpListener:
+    """Background listener that dispatches datagrams to a callback."""
+
+    def __init__(self, name: str, config: UdpConfig, handler: Handler):
+        self.name = name
+        self.config = config
+        self.handler = handler
+        self.socket = UdpSocket(config)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name=name, daemon=True)
+
+    def start(self) -> None:
+        if not self._thread.is_alive():
+            self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=2.0)
+        self.socket.close()
+
+    def _run(self) -> None:
+        sock = self.socket.sock
+        while not self._stop.is_set():
+            try:
+                data, addr = sock.recvfrom(self.config.recv_buffer)
+            except socket.timeout:
+                continue
+            except OSError as exc:
+                if not self._stop.is_set():
+                    print(f"[{self.name}] socket error: {exc}")
+                    time.sleep(0.1)
+                continue
+            try:
+                self.handler(data, addr)
+            except Exception as exc:  # pylint: disable=broad-except
+                print(f"[{self.name}] handler error: {exc}")
+
+
+class UdpSender:
+    """Shared UDP sender supporting broadcast overrides."""
+
+    def __init__(self, host: str, port: int, broadcast: bool = False):
+        cfg = UdpConfig(host="0.0.0.0", port=0, broadcast=broadcast, reuse=False)
+        self.socket = UdpSocket(cfg)
+        self.host = host
+        self.port = port
+
+    def send(self, payload: bytes, host: Optional[str] = None, port: Optional[int] = None) -> None:
+        dest_host = host or self.host
+        dest_port = port or self.port
+        try:
+            self.socket.sock.sendto(payload, (dest_host, dest_port))
+        except OSError as exc:
+            print(f"[UdpSender] send error to {dest_host}:{dest_port}: {exc}")
+
+    def close(self) -> None:
+        self.socket.close()
+
+
+__all__ = [
+    "DEFAULT_ROV_HOST",
+    "DEFAULT_BROADCAST",
+    "BUFFER_SIZE",
+    "Handler",
+    "next_sequence",
+    "UdpConfig",
+    "UdpSocket",
+    "UdpListener",
+    "UdpSender",
+]

--- a/lib/ninedof_receiver.py
+++ b/lib/ninedof_receiver.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
 import socket
 import json
 import threading
 import time
+from pathlib import Path
+from typing import Any
+
 from lib.json_data_handler import JSONDataHandler
 
 UDP_IP = "0.0.0.0"
 UDP_PORT = 5002
+LOG_DIR = Path("logs")
+IMU_LOG = LOG_DIR / "imu_raw.ndjson"
 
 # Default: identity mapping (sensor yaw/pitch/roll = ROV yaw/pitch/roll)
 DEFAULT_AXES = {"yaw": "+yaw", "pitch": "+pitch", "roll": "+roll"}
@@ -54,6 +61,7 @@ class IMUReceiver:
         # Axis remap (identity by default)
         self._remap = _build_remap(DEFAULT_AXES)
         self._accel_remap = _build_remap(DEFAULT_ACCEL_AXES, ("x", "y", "z"))
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
 
     def set_axis_mapping(self, axes_cfg):
         """Update YPR axis mapping at runtime."""
@@ -155,25 +163,35 @@ class IMUReceiver:
     def _process_packet(self, data: bytes, addr: tuple):
         """Process incoming UDP packet with IMU data."""
         try:
-            msg = json.loads(data.decode("utf-8", errors="strict"))
+            text = data.decode("utf-8", errors="strict")
+            msg = json.loads(text)
         except Exception as e:
             print(f"IMU: Bad JSON from {addr}: {e}")
             return
 
+        self._log_raw_packet(text)
+
         imu = msg.get("imu", {})
-        sensor_yaw = imu.get("yaw", 0.0)
-        sensor_pitch = imu.get("pitch", 0.0)
-        sensor_roll = imu.get("roll", 0.0)
+        def _val(key: str, default: float = float("nan")) -> float:
+            value = imu.get(key, default)
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return default
+
+        sensor_yaw = _val("yaw")
+        sensor_pitch = _val("pitch")
+        sensor_roll = _val("roll")
 
         # Angular rates (deg/s) — same remap applies
-        sensor_yr = imu.get("yr", 0.0)
-        sensor_pr = imu.get("pr", 0.0)
-        sensor_rr = imu.get("rr", 0.0)
+        sensor_yr = _val("yr")
+        sensor_pr = _val("pr")
+        sensor_rr = _val("rr")
 
         # Linear acceleration (m/s^2)
-        accel_x = imu.get("ax", 0.0)
-        accel_y = imu.get("ay", 0.0)
-        accel_z = imu.get("az", 0.0)
+        accel_x = _val("ax")
+        accel_y = _val("ay")
+        accel_z = _val("az")
 
         with self._lock:
             self._packet_count += 1
@@ -214,19 +232,32 @@ class IMUReceiver:
         try:
             self.data_handler.update_data({
                 "imu": {
-                    "yaw": round(yaw, 2),
-                    "pitch": round(pitch, 2),
-                    "roll": round(roll, 2),
-                    "yr": round(raw_yr, 2),
-                    "pr": round(raw_pr, 2),
-                    "rr": round(raw_rr, 2),
-                    "ax": round(mapped_ax, 3),
-                    "ay": round(mapped_ay, 3),
-                    "az": round(mapped_az, 3),
+                    "yaw": _coerce_json_number(yaw),
+                    "pitch": _coerce_json_number(pitch),
+                    "roll": _coerce_json_number(roll),
+                    "yr": _coerce_json_number(raw_yr),
+                    "pr": _coerce_json_number(raw_pr),
+                    "rr": _coerce_json_number(raw_rr),
+                    "ax": _coerce_json_number(mapped_ax, precision=3),
+                    "ay": _coerce_json_number(mapped_ay, precision=3),
+                    "az": _coerce_json_number(mapped_az, precision=3),
                 }
             })
         except Exception as e:
             print(f"IMU: Error updating data: {e}")
+
+    def _log_raw_packet(self, text: str) -> None:
+        try:
+            with IMU_LOG.open("a", encoding="utf-8") as fp:
+                fp.write(json.dumps({"ts": time.time(), "payload": text}) + "\n")
+        except OSError as exc:
+            print(f"IMU: failed to log packet: {exc}")
+
+
+def _coerce_json_number(value: float, precision: int = 2) -> Any:
+    if value != value:  # NaN check
+        return None
+    return round(float(value), precision)
 
 
 def init_imu_receiver(host=UDP_IP, port=UDP_PORT, data_handler=None) -> IMUReceiver:

--- a/lib/resource_receiver.py
+++ b/lib/resource_receiver.py
@@ -1,18 +1,31 @@
-"""
-Resource Monitor Receiver - UDP telemetry from Nucleo board
+from __future__ import annotations
 
-Receives telemetry packets containing CPU usage, memory stats, thread count,
-and network statistics. Packet format matches resource_monitor.h on the Nucleo.
+"""Resource monitor telemetry receiver.
+
+Decodes the packed ``telemetry_packet_t`` struct described in
+``resource_monitor.h`` and keeps ``data/data.json`` updated with the latest
+statistics so the web UI can present CPU, memory, and UDP health dashboards.
+
+Each packet is big-endian with an IEEE 802.3 CRC appended. This module shares
+the global CRC helper plus the UDP transport scaffolding so that the receiver
+matches the embedded ``crc32_calc()`` and ``net.c`` behavior exactly.
 """
 
-import socket
+import json
 import struct
 import threading
 import time
+from pathlib import Path
+
+from lib.crc import crc32_ieee
 from lib.json_data_handler import JSONDataHandler
+from lib.net_transport import UdpConfig, UdpListener
 
 UDP_IP = "0.0.0.0"
 UDP_PORT = 12346
+LOG_DIR = Path("logs")
+RESOURCE_LOG = LOG_DIR / "resource_monitor.ndjson"
+DIAG_LOG_EVERY_SEC = 5.0
 
 # Telemetry packet format (must match resource_monitor.h)
 # typedef struct {
@@ -32,37 +45,6 @@ UDP_PORT = 12346
 TELEMETRY_FORMAT = ">IIBBHHBBIII"  # Big-endian (network byte order)
 TELEMETRY_SIZE = struct.calcsize(TELEMETRY_FORMAT)
 
-# CRC32 lookup table (IEEE 802.3 polynomial)
-CRC32_TABLE = None
-
-
-def _init_crc32_table():
-    """Initialize CRC32 lookup table."""
-    global CRC32_TABLE
-    if CRC32_TABLE is not None:
-        return
-    CRC32_TABLE = []
-    for i in range(256):
-        crc = i
-        for _ in range(8):
-            if crc & 1:
-                crc = (crc >> 1) ^ 0xEDB88320
-            else:
-                crc >>= 1
-        CRC32_TABLE.append(crc)
-
-
-def _calculate_crc32(data: bytes) -> int:
-    """Calculate CRC32 checksum matching the embedded implementation."""
-    if CRC32_TABLE is None:
-        _init_crc32_table()
-    crc = 0xFFFFFFFF
-    for byte in data:
-        index = (crc ^ byte) & 0xFF
-        crc = (crc >> 8) ^ CRC32_TABLE[index]
-    return crc ^ 0xFFFFFFFF
-
-
 class ResourceReceiver:
     """Background UDP receiver for resource telemetry from Nucleo board."""
 
@@ -72,8 +54,7 @@ class ResourceReceiver:
         self.data_handler = data_handler or JSONDataHandler()
 
         self._stop = threading.Event()
-        self._thread = threading.Thread(target=self._run, name="ResourceReceiver", daemon=True)
-        self._sock = None
+        self._listener: UdpListener | None = None
 
         # Stats
         self._lock = threading.Lock()
@@ -83,31 +64,25 @@ class ResourceReceiver:
         self._packets_lost = 0
         self._last_data = {}
 
-        # Initialize CRC table
-        _init_crc32_table()
+        self._last_diag_log = 0.0
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
 
     def start(self):
         """Start the receiver thread."""
-        if self._thread.is_alive():
+        if self._listener is not None:
             return
-        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self._sock.bind((self.host, self.port))
-        self._sock.settimeout(1.0)  # Allow periodic stop checks
-        self._thread.start()
+        cfg = UdpConfig(host=self.host, port=self.port, broadcast=False, timeout=1.0, recv_buffer=1024)
+        self._listener = UdpListener("ResourceReceiver", cfg, self._process_packet)
+        self._stop.clear()
+        self._listener.start()
         print(f"Resource receiver started on {self.host}:{self.port}")
 
     def stop(self):
         """Stop the receiver thread."""
         self._stop.set()
-        if self._thread.is_alive():
-            self._thread.join(timeout=2.0)
-        if self._sock:
-            try:
-                self._sock.close()
-            except:
-                pass
-            self._sock = None
+        if self._listener:
+            self._listener.stop()
+            self._listener = None
         print("Resource receiver stopped")
 
     def get_stats(self) -> dict:
@@ -120,20 +95,6 @@ class ResourceReceiver:
                 "last_seq": self._last_seq,
                 "last_data": self._last_data.copy()
             }
-
-    def _run(self):
-        """Main receiver loop."""
-        while not self._stop.is_set():
-            try:
-                data, addr = self._sock.recvfrom(1024)
-                self._process_packet(data, addr)
-            except socket.timeout:
-                # Normal timeout, check stop flag
-                continue
-            except Exception as e:
-                if not self._stop.is_set():
-                    print(f"Resource receiver error: {e}")
-                time.sleep(0.1)
 
     def _process_packet(self, data: bytes, addr: tuple):
         """Process incoming UDP telemetry packet."""
@@ -152,7 +113,7 @@ class ResourceReceiver:
 
         # Validate CRC (calculated over all fields except CRC itself)
         crc_data = data[:-4]  # Everything except the last 4 bytes (CRC)
-        calculated_crc = _calculate_crc32(crc_data)
+        calculated_crc = crc32_ieee(crc_data)
 
         if calculated_crc != recv_crc:
             with self._lock:
@@ -194,6 +155,30 @@ class ResourceReceiver:
             self.data_handler.update_data({"resources": telemetry})
         except Exception as e:
             print(f"Resource: Error updating data: {e}")
+
+        self._maybe_log_diag(telemetry)
+
+    def _maybe_log_diag(self, telemetry: dict) -> None:
+        now = time.monotonic()
+        if now - self._last_diag_log < DIAG_LOG_EVERY_SEC:
+            return
+        self._last_diag_log = now
+        record = telemetry | {
+            "packets": self._packet_count,
+            "crc_errors": self._crc_errors,
+            "packets_lost": self._packets_lost,
+            "timestamp": time.time(),
+        }
+        try:
+            with RESOURCE_LOG.open("a", encoding="utf-8") as fp:
+                fp.write(json.dumps(record) + "\n")
+        except OSError as exc:
+            print(f"Resource: failed to log telemetry: {exc}")
+
+    def get_udp_counters(self) -> tuple[int, int]:
+        with self._lock:
+            last = self._last_data or {}
+            return last.get("udp_rx_count", 0), last.get("udp_rx_errors", 0)
 
 
 def init_resource_receiver(host=UDP_IP, port=UDP_PORT, data_handler=None) -> ResourceReceiver:

--- a/lib/setpoint_override.py
+++ b/lib/setpoint_override.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+"""Setpoint override client for the control firmware."""
+
+import struct
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict
+
+from lib.crc import crc32_ieee
+from lib.net_transport import DEFAULT_ROV_HOST, UdpSender
+
+AXES = ["surge", "sway", "heave", "roll", "pitch", "yaw"]
+AXIS_BITS = {axis: idx for idx, axis in enumerate(AXES)}
+SETPOINT_OVERRIDE_PORT = 5007
+TYPE_SET = 0x01
+TYPE_CLEAR = 0x02
+
+
+@dataclass
+class OverrideState:
+    active: bool = False
+    axes: Dict[str, float] = field(default_factory=lambda: {axis: 0.0 for axis in AXES})
+    last_error: str | None = None
+    last_update_ts: float = 0.0
+
+
+class SetpointOverrideClient:
+    def __init__(self, host: str = DEFAULT_ROV_HOST, port: int = SETPOINT_OVERRIDE_PORT, resource_monitor=None):
+        self.host = host
+        self.port = port
+        self.sender = UdpSender(host, port)
+        self.resource_monitor = resource_monitor
+        self._state = OverrideState()
+        self._lock = threading.Lock()
+        self._last_resource_errors = 0
+
+    def close(self) -> None:
+        self.sender.close()
+
+    def _check_resource_health(self) -> None:
+        if not self.resource_monitor:
+            return
+        counters = getattr(self.resource_monitor, "get_udp_counters", None)
+        if not counters:
+            return
+        _rx, errors = counters()
+        if errors > self._last_resource_errors:
+            raise RuntimeError("Resource monitor reports increasing UDP RX errors; refusing to send override")
+        self._last_resource_errors = errors
+
+    def send_override(self, axes: Dict[str, float], replay_attempts: int = 3, replay_delay: float = 0.05) -> dict:
+        self._check_resource_health()
+        values = [0.0] * len(AXES)
+        axis_mask = 0
+        for axis, value in axes.items():
+            if axis not in AXIS_BITS:
+                continue
+            idx = AXIS_BITS[axis]
+            axis_mask |= (1 << idx)
+            values[idx] = float(value)
+        if axis_mask == 0:
+            raise ValueError("No valid axes provided for override")
+        body = struct.pack("BB", TYPE_SET, axis_mask) + struct.pack("<" + "f" * len(values), *values)
+        crc = crc32_ieee(body)
+        packet = body + struct.pack("<I", crc & 0xFFFFFFFF)
+        for attempt in range(max(1, replay_attempts)):
+            self.sender.send(packet)
+            if attempt + 1 < replay_attempts:
+                time.sleep(replay_delay)
+        with self._lock:
+            self._state.active = True
+            for axis, value in axes.items():
+                if axis in self._state.axes:
+                    self._state.axes[axis] = float(value)
+            self._state.last_error = None
+            self._state.last_update_ts = time.time()
+        return self.get_state()
+
+    def clear_override(self) -> dict:
+        self._check_resource_health()
+        body = struct.pack("BB", TYPE_CLEAR, 0) + struct.pack("<" + "f" * len(AXES), *([0.0] * len(AXES)))
+        crc = crc32_ieee(body)
+        packet = body + struct.pack("<I", crc & 0xFFFFFFFF)
+        self.sender.send(packet)
+        with self._lock:
+            self._state.active = False
+            self._state.axes = {axis: 0.0 for axis in AXES}
+            self._state.last_error = None
+            self._state.last_update_ts = time.time()
+        return self.get_state()
+
+    def set_error(self, message: str) -> None:
+        with self._lock:
+            self._state.last_error = message
+            self._state.last_update_ts = time.time()
+
+    def get_state(self) -> dict:
+        with self._lock:
+            return {
+                "active": self._state.active,
+                "axes": dict(self._state.axes),
+                "last_error": self._state.last_error,
+                "last_update_ts": self._state.last_update_ts,
+            }
+
+
+def init_setpoint_override(host: str = DEFAULT_ROV_HOST, port: int = SETPOINT_OVERRIDE_PORT, resource_monitor=None) -> SetpointOverrideClient:
+    return SetpointOverrideClient(host=host, port=port, resource_monitor=resource_monitor)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ plotly==6.4.0
 requests==2.33.0
 pyserial==3.5
 pygame>=2.5
+pytest==9.0.2
 

--- a/routes.py
+++ b/routes.py
@@ -31,6 +31,15 @@ camera = init_camera()
 _DEFAULT_IMU_AXES = {"yaw": "+yaw", "pitch": "+pitch", "roll": "+roll"}
 _DEFAULT_ACCEL_AXES = {"x": "+x", "y": "+y", "z": "+z"}
 _DEFAULT_OFFSET = {"x": 0.0, "y": 0.0, "z": 0.0}
+ATTITUDE_LIMITS_DEG = {"roll": 45.0, "pitch": 45.0, "yaw": 180.0}
+
+
+def _clamp(value, lower, upper):
+    if value < lower:
+        return lower
+    if value > upper:
+        return upper
+    return value
 
 
 def _send_full_axis_config():
@@ -79,7 +88,7 @@ def register_routes(app):
     @app.route("/debug")
     def debug():
         """Render the debug slider page."""
-        return render_template("debug.html")
+        return render_template("debug.html", attitude_limits=ATTITUDE_LIMITS_DEG)
 
     @app.route("/graphs")
     def graphs():
@@ -177,6 +186,52 @@ def register_routes(app):
             return jsonify(DEFAULT_RESOURCES)
         return jsonify(resources)
 
+    @app.route("/api/command/status", methods=["GET"])
+    def get_command_status():
+        bm = current_app.config.get("BITMASK")
+        resource = current_app.config.get("RESOURCE")
+        override = current_app.config.get("SETPOINT_OVERRIDE")
+        uplink = bm.get_uplink_status() if bm else {}
+        udp_rx, udp_err = resource.get_udp_counters() if resource else (0, 0)
+        state = override.get_state() if override else {}
+        return jsonify({
+            "ok": True,
+            "uplink": uplink,
+            "udp_rx_count": udp_rx,
+            "udp_rx_errors": udp_err,
+            "override": state,
+        })
+
+    @app.route("/api/control/telemetry", methods=["GET"])
+    def control_telemetry():
+        receiver = current_app.config.get("CONTROL_TELEM")
+        latest = receiver.get_latest() if receiver else data_handler.get_section("control_telemetry")
+        return jsonify({"ok": bool(latest), "telemetry": latest or {}})
+
+    @app.route("/api/control/telemetry/history", methods=["GET"])
+    def control_telemetry_history():
+        receiver = current_app.config.get("CONTROL_TELEM")
+        limit = int(request.args.get("limit", "120"))
+        if receiver:
+            history = receiver.get_history(limit=limit)
+            return jsonify({"ok": True, "history": history})
+        return jsonify({"ok": False, "history": []}), 503
+
+    @app.route("/api/logs/live", methods=["GET"])
+    def live_logs():
+        limit = int(request.args.get("limit", "100"))
+        limit = max(1, min(500, limit))
+        log_stream = current_app.config.get("LOG_STREAM")
+        entries = log_stream.get_recent(limit) if log_stream else []
+        return jsonify({"ok": True, "logs": entries})
+
+    @app.route("/api/setpoint/status", methods=["GET"])
+    def setpoint_status():
+        client = current_app.config.get("SETPOINT_OVERRIDE")
+        if not client:
+            return jsonify({"ok": False, "error": "Setpoint override client unavailable"}), 503
+        return jsonify({"ok": True, "state": client.get_state()})
+
     @app.route("/api/rov/command", methods=["POST"])
     def set_rov_command():
         """
@@ -211,7 +266,17 @@ def register_routes(app):
     @app.route("/api/rov/status", methods=["GET"])
     def get_rov_status():
         bm = current_app.config["BITMASK"]
-        return jsonify({"ok": True, "command": bm.get_command()})
+        resource = current_app.config.get("RESOURCE")
+        udp_rx, udp_err = resource.get_udp_counters() if resource else (0, 0)
+        return jsonify({
+            "ok": True,
+            "command": bm.get_command(),
+            "uplink": bm.get_uplink_status(),
+            "resource": {
+                "udp_rx_count": udp_rx,
+                "udp_rx_errors": udp_err,
+            },
+        })
 
     @app.route("/api/imu/status", methods=["GET"])
     def get_imu_status():
@@ -315,17 +380,56 @@ def register_routes(app):
     # --- Debug override endpoints ---
     @app.route("/api/debug/override", methods=["POST"])
     def debug_override():
-        """Set debug override axes. Expects JSON with surge,sway,heave,roll,pitch,yaw in [-1..1]."""
+        """Set debug override axes as raw virtual joystick input via the bitmask command link."""
         data = request.get_json(force=True, silent=True) or {}
-        ctrl = current_app.config.get("CONTROLLER")
-        if not ctrl:
-            return jsonify({"ok": False, "error": "Controller not available"}), 503
+        bm = current_app.config.get("BITMASK")
+        if not bm:
+            return jsonify({"ok": False, "error": "Bitmask client unavailable"}), 503
         axes = {}
         for key in ("surge", "sway", "heave", "roll", "pitch", "yaw"):
             if key in data:
                 axes[key] = max(-1.0, min(1.0, float(data[key])))
-        ctrl.set_debug_override(axes)
+        if not axes:
+            return jsonify({"ok": False, "error": "No axes supplied"}), 400
+
+        bm.set_from_axes(**axes)
+
+        ctrl = current_app.config.get("CONTROLLER")
+        if ctrl:
+            ctrl.set_debug_override(axes)
+
         return jsonify({"ok": True, "override": axes})
+
+    @app.route("/api/debug/attitude_setpoint", methods=["POST"])
+    def debug_attitude_setpoint():
+        """Send roll/pitch/yaw setpoints in physical degrees via the override client."""
+        data = request.get_json(force=True, silent=True) or {}
+        client = current_app.config.get("SETPOINT_OVERRIDE")
+        if not client:
+            return jsonify({"ok": False, "error": "Setpoint override client unavailable"}), 503
+        axes = {}
+        for axis, limit in ATTITUDE_LIMITS_DEG.items():
+            if axis not in data:
+                continue
+            try:
+                value = float(data[axis])
+            except (TypeError, ValueError):
+                continue
+            axes[axis] = _clamp(value, -limit, limit)
+        if not axes:
+            return jsonify({"ok": False, "error": "No valid attitude axes supplied"}), 400
+        try:
+            state = client.send_override(axes, replay_attempts=5, replay_delay=0.1)
+        except Exception as exc:  # pylint: disable=broad-except
+            client.set_error(str(exc))
+            return jsonify({"ok": False, "error": str(exc)}), 503
+        return jsonify({
+            "ok": True,
+            "sent": axes,
+            "limits": ATTITUDE_LIMITS_DEG,
+            "state": state,
+            "units": "deg",
+        })
 
     @app.route("/api/debug/clear", methods=["POST"])
     def debug_clear():
@@ -333,6 +437,20 @@ def register_routes(app):
         ctrl = current_app.config.get("CONTROLLER")
         if ctrl:
             ctrl.clear_debug_override()
+
+        # Zero out the bitmask axes (slider override path)
+        bm = current_app.config.get("BITMASK")
+        if bm:
+            bm.set_from_axes(surge=0, sway=0, heave=0, roll=0, pitch=0, yaw=0)
+
+        # Clear any setpoint override on port 5007 (attitude override path)
+        client = current_app.config.get("SETPOINT_OVERRIDE")
+        if client:
+            try:
+                client.clear_override()
+            except Exception:
+                pass
+
         return jsonify({"ok": True})
 
     # --- Gain endpoints ---

--- a/static/css/debug.css
+++ b/static/css/debug.css
@@ -97,3 +97,66 @@
   0%, 100% { opacity: 1; }
   50% { opacity: 0.6; }
 }
+
+/* Control loop visualizer */
+.control-chart-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 0.75rem;
+  min-height: 210px;
+}
+
+.control-chart {
+  width: 100%;
+  height: 110px;
+  display: block;
+}
+
+.chart-legend {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  display: inline-block;
+  border-radius: 2px;
+  margin-right: 0.2rem;
+}
+
+.legend-setpoint { background: #0dcaf0; }
+.legend-output { background: #20c997; }
+.legend-error { background: #ffc107; }
+
+.attitude-field-row .form-control {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
+.attitude-field-row .form-control:focus {
+  border-color: #0dcaf0;
+  box-shadow: 0 0 0 0.1rem rgba(13, 202, 240, 0.25);
+}
+
+#attitude-feedback {
+  min-width: 200px;
+}
+
+.axis-status {
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+}
+
+.telemetry-row.override-active td {
+  background: rgba(220, 53, 69, 0.1);
+}
+
+.log-stream {
+  background: rgba(0, 0, 0, 0.4);
+  min-height: 240px;
+}

--- a/static/js/debug.js
+++ b/static/js/debug.js
@@ -2,9 +2,22 @@
 (function () {
   const AXES = ["surge", "sway", "heave", "roll", "pitch", "yaw"];
   const SEND_INTERVAL_MS = 50; // 20 Hz updates while override is active
+  const HISTORY_LIMIT = 120; // 12 seconds of telemetry samples
 
   let overrideActive = false;
   let sendTimer = null;
+  let overrideState = null;
+  let chartFrameScheduled = false;
+  let lastTelemetry = null;
+
+  const axisHistory = AXES.reduce((acc, axis) => {
+    acc[axis] = {
+      setpoint: [],
+      output: [],
+      error: [],
+    };
+    return acc;
+  }, {});
 
   // DOM refs
   const btnEnable = document.getElementById("btn-enable");
@@ -12,6 +25,27 @@
   const btnResetAll = document.getElementById("btn-reset-all");
   const statusBadge = document.getElementById("debug-status");
   const rovStatus = document.getElementById("rov-status");
+  const telemetryBody = document.getElementById("control-telemetry-body");
+  const telemetryAge = document.getElementById("control-telemetry-age");
+  const uplinkStatusBadge = document.getElementById("uplink-status-badge");
+  const uplinkSequence = document.getElementById("uplink-sequence");
+  const uplinkSendAge = document.getElementById("uplink-send-age");
+  const uplinkAckAge = document.getElementById("uplink-ack-age");
+  const uplinkUdpRx = document.getElementById("uplink-udp-rx");
+  const uplinkUdpErrors = document.getElementById("uplink-udp-errors");
+  const uplinkResends = document.getElementById("uplink-resends");
+  const overrideStatusChip = document.getElementById("override-status-chip");
+  const overrideAxes = document.getElementById("override-axes");
+  const logStreamEl = document.getElementById("log-stream");
+  const ATTITUDE_AXES = ["roll", "pitch", "yaw"];
+  const attitudeLimits = window.debugAttitudeLimits || {};
+  const attRollInput = document.getElementById("attitude-roll");
+  const attPitchInput = document.getElementById("attitude-pitch");
+  const attYawInput = document.getElementById("attitude-yaw");
+  const btnAttitudeSend = document.getElementById("btn-attitude-send");
+  const btnAttitudeClear = document.getElementById("btn-attitude-clear");
+  const attitudeFeedback = document.getElementById("attitude-feedback");
+  const attitudeStatus = document.getElementById("attitude-status");
 
   // --- Slider helpers ---
   function getSliderValue(axis) {
@@ -42,6 +76,124 @@
     updateValueDisplay(axis);
   }
 
+  // --- Control telemetry helpers ---
+  function pushTelemetrySample(sample) {
+    if (!sample || !sample.setpoint) return;
+    lastTelemetry = sample;
+    AXES.forEach((axis) => {
+      const store = axisHistory[axis];
+      ["setpoint", "output", "error"].forEach((key) => {
+        const source = sample[key] || {};
+        const value = typeof source[axis] === "number" ? source[axis] : NaN;
+        const series = store[key];
+        series.push(value);
+        if (series.length > HISTORY_LIMIT) {
+          series.shift();
+        }
+      });
+    });
+    requestChartRender();
+  }
+
+  function requestChartRender() {
+    if (chartFrameScheduled) return;
+    chartFrameScheduled = true;
+    window.requestAnimationFrame(() => {
+      drawAllCharts();
+      chartFrameScheduled = false;
+    });
+  }
+
+  function drawAllCharts() {
+    AXES.forEach((axis) => drawAxisChart(axis));
+  }
+
+  function drawAxisChart(axis) {
+    const canvas = document.getElementById("chart-" + axis);
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    const width = canvas.clientWidth || canvas.width;
+    const height = canvas.clientHeight || canvas.height;
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+    }
+    const store = axisHistory[axis];
+    const values = [...store.setpoint, ...store.output, ...store.error].filter((v) => typeof v === "number" && !Number.isNaN(v));
+    const min = values.length ? Math.min(...values) : -1;
+    const max = values.length ? Math.max(...values) : 1;
+    const span = max - min || 1;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    function drawSeries(series, color, width = 1.5) {
+      if (!series.length) return;
+      ctx.beginPath();
+      ctx.strokeStyle = color;
+      ctx.lineWidth = width;
+      let started = false;
+      series.forEach((value, idx) => {
+        const normalized = Number.isNaN(value) ? null : value;
+        if (normalized == null) return;
+        const x = (idx / Math.max(series.length - 1, 1)) * canvas.width;
+        const y = canvas.height - ((normalized - min) / span) * canvas.height;
+        if (!started) {
+          ctx.moveTo(x, y);
+          started = true;
+        } else {
+          ctx.lineTo(x, y);
+        }
+      });
+      if (started) ctx.stroke();
+    }
+
+    drawSeries(store.setpoint, "#0dcaf0", 2);
+    drawSeries(store.output, "#20c997", 2);
+    drawSeries(store.error, "#ffc107", 1.5);
+
+    // midline
+    ctx.beginPath();
+    ctx.strokeStyle = "rgba(255,255,255,0.1)";
+    ctx.lineWidth = 1;
+    const midY = canvas.height - ((0 - min) / span) * canvas.height;
+    ctx.moveTo(0, midY);
+    ctx.lineTo(canvas.width, midY);
+    ctx.stroke();
+  }
+
+  function axisOverrideActive(axis) {
+    if (!overrideState || !overrideState.active) return false;
+    const axes = overrideState.axes || {};
+    const value = axes[axis];
+    return typeof value === "number" && Math.abs(value) > 0.01;
+  }
+
+  function updateAxisStatus(axis, errorValue) {
+    const badge = document.getElementById("axis-status-" + axis);
+    if (!badge) return;
+    const override = axisOverrideActive(axis);
+    if (override) {
+      badge.textContent = "OVR";
+      badge.className = "badge bg-danger axis-status";
+      return;
+    }
+    if (errorValue == null || Number.isNaN(errorValue)) {
+      badge.textContent = "NA";
+      badge.className = "badge bg-secondary axis-status";
+      return;
+    }
+    const absErr = Math.abs(errorValue);
+    if (absErr < 0.05) {
+      badge.textContent = "LOCK";
+      badge.className = "badge bg-success axis-status";
+    } else if (absErr < 0.2) {
+      badge.textContent = "TRACK";
+      badge.className = "badge bg-warning text-dark axis-status";
+    } else {
+      badge.textContent = "OFF";
+      badge.className = "badge bg-danger axis-status";
+    }
+  }
+
   // --- API calls ---
   async function sendOverride() {
     if (!overrideActive) return;
@@ -58,9 +210,11 @@
 
   async function clearOverride() {
     try {
-      await fetch("/api/debug/clear", { method: "POST" });
+      const res = await fetch("/api/debug/clear", { method: "POST" });
+      return res.ok;
     } catch (e) {
       console.error("Failed to clear debug override:", e);
+      return false;
     }
   }
 
@@ -68,9 +222,176 @@
     try {
       const res = await fetch("/api/rov/status");
       const data = await res.json();
-      rovStatus.textContent = JSON.stringify(data.command, null, 2);
+      rovStatus.textContent = JSON.stringify({
+        command: data.command,
+        uplink: data.uplink,
+        resource: data.resource,
+      }, null, 2);
     } catch (_) {
       rovStatus.textContent = "Error fetching status";
+    }
+  }
+
+  function fmtMs(value) {
+    if (value == null) return "--";
+    return value.toFixed(0);
+  }
+
+  function fmtFloat(value, digits = 2) {
+    if (value == null || Number.isNaN(value)) return "NaN";
+    return value.toFixed(digits);
+  }
+
+  function updateTelemetryAgeLabel(snapshot) {
+    if (!telemetryAge) return;
+    const ageMs = snapshot && snapshot.timestamp ? Math.max(0, Date.now() - snapshot.timestamp * 1000) : null;
+    telemetryAge.textContent = fmtMs(ageMs);
+  }
+
+  function renderTelemetryTable(snapshot) {
+    if (!telemetryBody) return;
+    const setpoint = (snapshot && snapshot.setpoint) || {};
+    const output = (snapshot && snapshot.output) || {};
+    const error = (snapshot && snapshot.error) || {};
+    const frag = document.createDocumentFragment();
+    AXES.forEach((axis) => {
+      const tr = document.createElement("tr");
+      tr.className = "telemetry-row";
+      if (axisOverrideActive(axis)) tr.classList.add("override-active");
+      const tdAxis = document.createElement("td");
+      tdAxis.textContent = axis.toUpperCase();
+      const tdSet = document.createElement("td");
+      tdSet.textContent = fmtFloat(setpoint[axis]);
+      const tdOut = document.createElement("td");
+      tdOut.textContent = fmtFloat(output[axis]);
+      const tdErr = document.createElement("td");
+      tdErr.textContent = fmtFloat(error[axis]);
+      tr.append(tdAxis, tdSet, tdOut, tdErr);
+      frag.appendChild(tr);
+      updateAxisStatus(axis, error[axis]);
+    });
+    telemetryBody.innerHTML = "";
+    telemetryBody.appendChild(frag);
+  }
+
+  async function pollControlTelemetry() {
+    try {
+      const res = await fetch("/api/control/telemetry");
+      const data = await res.json();
+      if (!data.ok) return;
+      pushTelemetrySample(data.telemetry);
+      renderTelemetryTable(data.telemetry);
+      updateTelemetryAgeLabel(data.telemetry);
+    } catch (err) {
+      console.error("control telemetry poll failed", err);
+    }
+  }
+
+  async function bootstrapTelemetryHistory() {
+    try {
+      const res = await fetch(`/api/control/telemetry/history?limit=${HISTORY_LIMIT}`);
+      const data = await res.json();
+      if (!data.ok) return;
+      (data.history || []).forEach((sample) => pushTelemetrySample(sample));
+      if (data.history && data.history.length) {
+        const latest = data.history[data.history.length - 1];
+        renderTelemetryTable(latest);
+        updateTelemetryAgeLabel(latest);
+      }
+    } catch (err) {
+      console.error("bootstrap telemetry history failed", err);
+    }
+  }
+
+  function renderOverrideState(state) {
+    if (!overrideAxes || !overrideStatusChip) return;
+    overrideState = state || null;
+    const active = !!(state && state.active);
+    overrideStatusChip.textContent = active ? "ACTIVE" : "INACTIVE";
+    overrideStatusChip.className = `badge ${active ? "bg-danger" : "bg-secondary"}`;
+    const axes = (state && state.axes) || {};
+    const entries = AXES.filter((axis) => Math.abs(axes[axis] || 0) > 0.01)
+      .map((axis) => `<span class="badge bg-dark me-1 mb-1">${axis}: ${fmtFloat(axes[axis])}</span>`);
+    let html = entries.length ? entries.join(" ") : '<span class="text-muted">No overrides</span>';
+    if (state && state.last_error) {
+      html += `<div class="text-danger small mt-2">${state.last_error}</div>`;
+    }
+    overrideAxes.innerHTML = html;
+  }
+
+  function updateUplinkStatus(payload, udp, override) {
+    if (!uplinkSequence) return;
+    uplinkSequence.textContent = payload && typeof payload.sequence !== "undefined" ? payload.sequence : "--";
+    uplinkSendAge.textContent = fmtMs(payload ? payload.last_send_age_ms : null);
+    uplinkAckAge.textContent = fmtMs(payload ? payload.last_ack_age_ms : null);
+    uplinkUdpRx.textContent = udp && typeof udp.count !== "undefined" ? udp.count : "--";
+    uplinkUdpErrors.textContent = udp && typeof udp.errors !== "undefined" ? udp.errors : "--";
+    uplinkResends.textContent = payload && typeof payload.watchdog_resends !== "undefined" ? payload.watchdog_resends : 0;
+    const ackAge = payload && typeof payload.last_ack_age_ms !== "undefined" ? payload.last_ack_age_ms : null;
+    if (ackAge == null) {
+      uplinkStatusBadge.textContent = "IDLE";
+      uplinkStatusBadge.className = "badge bg-secondary";
+    } else if (ackAge < 1000) {
+      uplinkStatusBadge.textContent = "LIVE";
+      uplinkStatusBadge.className = "badge bg-success";
+    } else if (ackAge < 3000) {
+      uplinkStatusBadge.textContent = "STALE";
+      uplinkStatusBadge.className = "badge bg-warning text-dark";
+    } else {
+      uplinkStatusBadge.textContent = "DEGRADED";
+      uplinkStatusBadge.className = "badge bg-danger";
+    }
+    renderOverrideState(override);
+  }
+
+  async function pollCommandStatus() {
+    try {
+      const res = await fetch("/api/command/status");
+      const data = await res.json();
+      if (!data.ok) return;
+      updateUplinkStatus(data.uplink, { count: data.udp_rx_count, errors: data.udp_rx_errors }, data.override);
+    } catch (err) {
+      console.error("command status poll failed", err);
+    }
+  }
+
+  function renderLogs(entries) {
+    if (!logStreamEl) return;
+    const frag = document.createDocumentFragment();
+    entries.forEach((entry) => {
+      const row = document.createElement("div");
+      row.className = "d-flex justify-content-between border-bottom border-secondary py-1";
+      const body = document.createElement("div");
+      const level = entry.level || "I";
+      const badge = document.createElement("span");
+      const levelMap = { I: "bg-info text-dark", W: "bg-warning text-dark", R: "bg-danger", D: "bg-secondary" };
+      badge.className = `badge me-2 ${levelMap[level] || "bg-secondary"}`;
+      badge.textContent = level;
+      body.appendChild(badge);
+      const msg = document.createElement("span");
+      msg.textContent = entry.message || "";
+      body.appendChild(msg);
+      const ts = document.createElement("span");
+      ts.className = "text-light-muted small ms-3";
+      const tsValue = entry.ts ? new Date(entry.ts * 1000) : new Date();
+      ts.textContent = tsValue.toLocaleTimeString();
+      row.appendChild(body);
+      row.appendChild(ts);
+      frag.appendChild(row);
+    });
+    logStreamEl.innerHTML = "";
+    logStreamEl.appendChild(frag);
+    logStreamEl.scrollTop = logStreamEl.scrollHeight;
+  }
+
+  async function pollLogs() {
+    try {
+      const res = await fetch("/api/logs/live?limit=50");
+      const data = await res.json();
+      if (!data.ok) return;
+      renderLogs(data.logs || []);
+    } catch (err) {
+      console.error("log stream poll failed", err);
     }
   }
 
@@ -88,18 +409,21 @@
     sendTimer = setInterval(sendOverride, SEND_INTERVAL_MS);
   }
 
-  function disableOverride() {
+  function resetOverrideUi() {
     overrideActive = false;
     btnEnable.disabled = false;
     btnDisable.disabled = true;
     statusBadge.textContent = "INACTIVE";
     statusBadge.classList.remove("bg-danger", "active");
     statusBadge.classList.add("bg-secondary");
-
     if (sendTimer) {
       clearInterval(sendTimer);
       sendTimer = null;
     }
+  }
+
+  function disableOverride() {
+    resetOverrideUi();
     clearOverride();
   }
 
@@ -118,6 +442,13 @@
   // Poll ROV status every 500 ms
   pollStatus();
   setInterval(pollStatus, 500);
+  pollCommandStatus();
+  setInterval(pollCommandStatus, 1000);
+  bootstrapTelemetryHistory();
+  pollControlTelemetry();
+  setInterval(pollControlTelemetry, 200);
+  pollLogs();
+  setInterval(pollLogs, 1500);
 
   // IMU Live Readout
   const imuStatus = document.getElementById("imu-status");
@@ -561,4 +892,76 @@
 
   // Load config list on page load
   refreshConfigList();
+
+  // --- Attitude Setpoint Override ---
+  function setAttitudeStatus(text, cls) {
+    attitudeStatus.textContent = text;
+    attitudeStatus.className = "badge " + cls;
+  }
+
+  btnAttitudeSend.addEventListener("click", async function () {
+    var payload = {};
+    var roll = parseFloat(attRollInput.value);
+    var pitch = parseFloat(attPitchInput.value);
+    var yaw = parseFloat(attYawInput.value);
+    if (!isNaN(roll)) payload.roll = roll;
+    if (!isNaN(pitch)) payload.pitch = pitch;
+    if (!isNaN(yaw)) payload.yaw = yaw;
+    if (Object.keys(payload).length === 0) {
+      attitudeFeedback.textContent = "Enter at least one value.";
+      attitudeFeedback.className = "small text-warning ms-auto";
+      return;
+    }
+    setAttitudeStatus("SENDING…", "bg-warning text-dark");
+    btnAttitudeSend.disabled = true;
+    try {
+      var res = await fetch("/api/debug/attitude_setpoint", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      var data = await res.json();
+      if (data.ok) {
+        var sent = data.sent || {};
+        var parts = Object.entries(sent).map(function (kv) {
+          return kv[0] + "=" + kv[1].toFixed(1) + "°";
+        });
+        attitudeFeedback.textContent = "Sent: " + parts.join(", ");
+        attitudeFeedback.className = "small text-success ms-auto";
+        setAttitudeStatus("ACTIVE", "bg-danger");
+      } else {
+        attitudeFeedback.textContent = data.error || "Failed";
+        attitudeFeedback.className = "small text-danger ms-auto";
+        setAttitudeStatus("ERROR", "bg-danger");
+      }
+    } catch (e) {
+      attitudeFeedback.textContent = "Error: " + e.message;
+      attitudeFeedback.className = "small text-danger ms-auto";
+      setAttitudeStatus("ERROR", "bg-danger");
+    }
+    btnAttitudeSend.disabled = false;
+  });
+
+  btnAttitudeClear.addEventListener("click", async function () {
+    setAttitudeStatus("CLEARING…", "bg-warning text-dark");
+    btnAttitudeClear.disabled = true;
+    try {
+      var res = await fetch("/api/debug/clear", { method: "POST" });
+      var data = await res.json();
+      if (data.ok) {
+        attitudeFeedback.textContent = "Override cleared.";
+        attitudeFeedback.className = "small text-light-muted ms-auto";
+        setAttitudeStatus("IDLE", "bg-secondary");
+      } else {
+        attitudeFeedback.textContent = data.error || "Failed to clear";
+        attitudeFeedback.className = "small text-danger ms-auto";
+        setAttitudeStatus("ERROR", "bg-danger");
+      }
+    } catch (e) {
+      attitudeFeedback.textContent = "Error: " + e.message;
+      attitudeFeedback.className = "small text-danger ms-auto";
+      setAttitudeStatus("ERROR", "bg-danger");
+    }
+    btnAttitudeClear.disabled = false;
+  });
 })();

--- a/static/templates/debug.html
+++ b/static/templates/debug.html
@@ -4,6 +4,9 @@
 
 {% block content %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/debug.css') }}">
+<script>
+  window.debugAttitudeLimits = {{ attitude_limits|default({})|tojson|safe }};
+</script>
 
 <!-- IMU Live Readout -->
 <div class="row g-4">
@@ -290,6 +293,52 @@
   </div>
 </div>
 
+      <!-- Attitude Setpoint Override -->
+      <div class="row g-4 mt-1">
+        <div class="col-12">
+          <div class="card custom-card">
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-center mb-3">
+                <h5 class="card-title mb-0">Attitude Setpoint Override (°)</h5>
+                <span id="attitude-status" class="badge bg-secondary">IDLE</span>
+              </div>
+              <p class="text-muted small mb-4">
+                Push exact roll, pitch, and yaw setpoints down to the flight controller. Values are clamped to ±{{ attitude_limits.roll }}° (roll/pitch)
+                and ±{{ attitude_limits.yaw }}° (yaw). Use this for heading-hold experiments without touching the raw thruster sliders.
+              </p>
+              <div class="row g-3 attitude-field-row">
+                <div class="col-md-4">
+                  <label class="form-label small text-light-muted">Roll (±{{ attitude_limits.roll }}°)</label>
+                  <div class="input-group input-group-sm">
+                    <input type="number" class="form-control bg-dark text-light" id="attitude-roll" step="0.1" placeholder="0.0">
+                    <span class="input-group-text">deg</span>
+                  </div>
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label small text-light-muted">Pitch (±{{ attitude_limits.pitch }}°)</label>
+                  <div class="input-group input-group-sm">
+                    <input type="number" class="form-control bg-dark text-light" id="attitude-pitch" step="0.1" placeholder="0.0">
+                    <span class="input-group-text">deg</span>
+                  </div>
+                </div>
+                <div class="col-md-4">
+                  <label class="form-label small text-light-muted">Yaw (±{{ attitude_limits.yaw }}°)</label>
+                  <div class="input-group input-group-sm">
+                    <input type="number" class="form-control bg-dark text-light" id="attitude-yaw" step="0.1" placeholder="0.0">
+                    <span class="input-group-text">deg</span>
+                  </div>
+                </div>
+              </div>
+              <div class="d-flex align-items-center gap-2 flex-wrap mt-4">
+                <button id="btn-attitude-send" class="btn btn-sm btn-primary">Send Setpoints</button>
+                <button id="btn-attitude-clear" class="btn btn-sm btn-outline-secondary">Clear Attitude Override</button>
+                <div id="attitude-feedback" class="small text-light-muted ms-auto">Waiting for input…</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
 <!-- PID Configuration -->
 <div class="row g-4 mt-1">
   <div class="col-12">
@@ -391,13 +440,188 @@
   </div>
 </div>
 
+<!-- Control Telemetry & Command Link -->
+<div class="row g-4 mt-1">
+  <div class="col-lg-6">
+    <div class="card custom-card h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h5 class="card-title mb-0">Control Telemetry</h5>
+          <small class="text-light-muted">Updated <span id="control-telemetry-age">--</span> ms ago</small>
+        </div>
+        <div class="table-responsive">
+          <table class="table table-dark table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th>Axis</th>
+                <th>Setpoint</th>
+                <th>Output</th>
+                <th>Error</th>
+              </tr>
+            </thead>
+            <tbody id="control-telemetry-body">
+              <tr><td colspan="4" class="text-center text-muted">Waiting for packets…</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-6">
+    <div class="card custom-card h-100">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <h5 class="card-title mb-0">Command Link Health</h5>
+          <span id="uplink-status-badge" class="badge bg-secondary">IDLE</span>
+        </div>
+        <p class="text-muted small mb-2">Sequence <span id="uplink-sequence">--</span> · Last send <span id="uplink-send-age">--</span> ms · Last ack <span id="uplink-ack-age">--</span> ms</p>
+        <div class="row g-2 mb-3">
+          <div class="col-sm-6">
+            <div class="small text-light-muted">UDP RX Count</div>
+            <div class="fs-5" id="uplink-udp-rx">--</div>
+          </div>
+          <div class="col-sm-6">
+            <div class="small text-light-muted">RX Errors</div>
+            <div class="fs-5" id="uplink-udp-errors">--</div>
+          </div>
+        </div>
+        <div class="small text-light-muted">Watchdog Resends</div>
+        <div class="fs-6 mb-3" id="uplink-resends">0</div>
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <h6 class="mb-0">Override State</h6>
+          <span id="override-status-chip" class="badge bg-secondary">INACTIVE</span>
+        </div>
+        <div id="override-axes" class="small text-light"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Control Loop Visualizer -->
+<div class="row g-4 mt-1">
+  <div class="col-12">
+    <div class="card custom-card">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h5 class="card-title mb-0">Control Loop Visualizer</h5>
+          <small class="text-light-muted">10&nbsp;Hz history of setpoint, output, and error</small>
+        </div>
+        <div class="row g-3" id="control-chart-grid">
+          <div class="col-md-4 col-xl-2" id="chart-card-surge">
+            <div class="control-chart-card">
+              <div class="d-flex justify-content-between align-items-center mb-1">
+                <span class="text-uppercase text-light-muted fw-semibold small">Surge</span>
+                <span class="badge bg-secondary axis-status" id="axis-status-surge">--</span>
+              </div>
+              <canvas class="control-chart" id="chart-surge" width="320" height="120"></canvas>
+              <div class="chart-legend small text-light-muted">
+                <span class="legend-swatch legend-setpoint"></span> Setpoint
+                <span class="legend-swatch legend-output ms-2"></span> Output
+                <span class="legend-swatch legend-error ms-2"></span> Error
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 col-xl-2" id="chart-card-sway">
+            <div class="control-chart-card">
+              <div class="d-flex justify-content-between align-items-center mb-1">
+                <span class="text-uppercase text-light-muted fw-semibold small">Sway</span>
+                <span class="badge bg-secondary axis-status" id="axis-status-sway">--</span>
+              </div>
+              <canvas class="control-chart" id="chart-sway" width="320" height="120"></canvas>
+              <div class="chart-legend small text-light-muted">
+                <span class="legend-swatch legend-setpoint"></span> Setpoint
+                <span class="legend-swatch legend-output ms-2"></span> Output
+                <span class="legend-swatch legend-error ms-2"></span> Error
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 col-xl-2" id="chart-card-heave">
+            <div class="control-chart-card">
+              <div class="d-flex justify-content-between align-items-center mb-1">
+                <span class="text-uppercase text-light-muted fw-semibold small">Heave</span>
+                <span class="badge bg-secondary axis-status" id="axis-status-heave">--</span>
+              </div>
+              <canvas class="control-chart" id="chart-heave" width="320" height="120"></canvas>
+              <div class="chart-legend small text-light-muted">
+                <span class="legend-swatch legend-setpoint"></span> Setpoint
+                <span class="legend-swatch legend-output ms-2"></span> Output
+                <span class="legend-swatch legend-error ms-2"></span> Error
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 col-xl-2" id="chart-card-roll">
+            <div class="control-chart-card">
+              <div class="d-flex justify-content-between align-items-center mb-1">
+                <span class="text-uppercase text-light-muted fw-semibold small">Roll</span>
+                <span class="badge bg-secondary axis-status" id="axis-status-roll">--</span>
+              </div>
+              <canvas class="control-chart" id="chart-roll" width="320" height="120"></canvas>
+              <div class="chart-legend small text-light-muted">
+                <span class="legend-swatch legend-setpoint"></span> Setpoint
+                <span class="legend-swatch legend-output ms-2"></span> Output
+                <span class="legend-swatch legend-error ms-2"></span> Error
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 col-xl-2" id="chart-card-pitch">
+            <div class="control-chart-card">
+              <div class="d-flex justify-content-between align-items-center mb-1">
+                <span class="text-uppercase text-light-muted fw-semibold small">Pitch</span>
+                <span class="badge bg-secondary axis-status" id="axis-status-pitch">--</span>
+              </div>
+              <canvas class="control-chart" id="chart-pitch" width="320" height="120"></canvas>
+              <div class="chart-legend small text-light-muted">
+                <span class="legend-swatch legend-setpoint"></span> Setpoint
+                <span class="legend-swatch legend-output ms-2"></span> Output
+                <span class="legend-swatch legend-error ms-2"></span> Error
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4 col-xl-2" id="chart-card-yaw">
+            <div class="control-chart-card">
+              <div class="d-flex justify-content-between align-items-center mb-1">
+                <span class="text-uppercase text-light-muted fw-semibold small">Yaw</span>
+                <span class="badge bg-secondary axis-status" id="axis-status-yaw">--</span>
+              </div>
+              <canvas class="control-chart" id="chart-yaw" width="320" height="120"></canvas>
+              <div class="chart-legend small text-light-muted">
+                <span class="legend-swatch legend-setpoint"></span> Setpoint
+                <span class="legend-swatch legend-output ms-2"></span> Output
+                <span class="legend-swatch legend-error ms-2"></span> Error
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Live ROV Command readout -->
 <div class="row g-4 mt-1">
   <div class="col-12">
     <div class="card custom-card">
       <div class="card-body">
-        <h5 class="card-title">Live ROV Command</h5>
-        <pre id="rov-status" class="text-light mb-0" style="font-size: 0.85rem;">Loading...</pre>
+        <div class="d-flex justify-content-between align-items-center">
+          <h5 class="card-title mb-0">Live Packages Sent from Topside</h5>
+          <small class="text-light-muted">Bitmask payload preview &amp; raw command snapshot</small>
+        </div>
+        <pre id="rov-status" class="text-light mb-0 mt-3" style="font-size: 0.85rem;">Loading...</pre>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Log Stream -->
+<div class="row g-4 mt-1">
+  <div class="col-12">
+    <div class="card custom-card">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <h5 class="card-title mb-0">Zephyr Log Stream</h5>
+          <small class="text-light-muted">Latest 50 entries</small>
+        </div>
+        <div id="log-stream" class="log-stream border border-secondary rounded" style="min-height: 200px; max-height: 320px; overflow-y: auto; font-family: var(--bs-font-monospace); font-size: 0.8rem;"></div>
       </div>
     </div>
   </div>

--- a/tests/test_control_telemetry.py
+++ b/tests/test_control_telemetry.py
@@ -1,0 +1,32 @@
+"""Send a fake control telemetry packet to localhost:5005 to verify the receiver works."""
+
+import socket
+import struct
+import binascii
+
+AXES = ["surge", "sway", "heave", "roll", "pitch", "yaw"]
+PORT = 5005
+
+# Build a packet matching the firmware format:
+# sequence (u32 BE) | setpoint[6] (f32 LE) | output[6] (f32 LE) | error[6] (f32 LE) | crc32 (u32 BE)
+
+sequence = 1
+setpoints = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+outputs   = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+errors    = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+body  = struct.pack(">I", sequence)
+body += struct.pack("<6f", *setpoints)
+body += struct.pack("<6f", *outputs)
+body += struct.pack("<6f", *errors)
+
+crc = binascii.crc32(body) & 0xFFFFFFFF
+packet = body + struct.pack(">I", crc)
+
+print(f"Packet size: {len(packet)} bytes (expected 80)")
+print(f"CRC: 0x{crc:08X}")
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.sendto(packet, ("127.0.0.1", PORT))
+print(f"Sent to 127.0.0.1:{PORT}")
+sock.close()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,0 +1,58 @@
+import struct
+
+import pytest
+
+from lib import bitmask
+from lib import crc
+import lib.control_telemetry as control_telem
+
+
+class DummyHandler:
+    def __init__(self):
+        self.last_update = None
+
+    def update_data(self, payload):
+        self.last_update = payload
+
+
+def test_crc32_ieee_standard_vector():
+    # Known-good IEEE 802.3 vector
+    assert crc.crc32_ieee(b"123456789") == 0xCBF43926
+
+
+def test_bitmask_packet_big_endian():
+    seq = 0x12345678
+    payload = 0x0123456789ABCDEF
+    pkt = bitmask.build_packet(seq, payload)
+    assert len(pkt) == 16
+    assert pkt[:4] == struct.pack("!I", seq)
+    assert pkt[4:12] == struct.pack("!Q", payload)
+    expected_crc = crc.crc32_ieee(struct.pack("!IQ", seq, payload))
+    assert pkt[12:] == struct.pack("!I", expected_crc)
+
+
+def test_control_telemetry_history(monkeypatch, tmp_path):
+    monkeypatch.setattr(control_telem, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(control_telem, "CONTROL_LOG", tmp_path / "control_telemetry.ndjson")
+    handler = DummyHandler()
+    receiver = control_telem.ControlTelemetryReceiver(data_handler=handler)
+    receiver.disable_capture()
+
+    sequence = 0x11223344
+    setpoints = [0.1 * idx for idx in range(6)]
+    outputs = [value + 0.05 for value in setpoints]
+    errors = [output - value for value, output in zip(setpoints, outputs)]
+    body = struct.pack("!I", sequence) + struct.pack("<" + "f" * 18, *(setpoints + outputs + errors))
+    crc_value = crc.crc32_ieee(body)
+    packet = body + struct.pack("!I", crc_value)
+
+    receiver._handle_packet(packet, ("127.0.0.1", 5005))  # pylint: disable=protected-access
+
+    latest = receiver.get_latest()
+    assert latest["sequence"] == sequence
+    for axis, value in zip(control_telem.AXES, setpoints):
+        assert latest["setpoint"][axis] == pytest.approx(value, rel=1e-4)
+    history = receiver.get_history(limit=5)
+    assert len(history) == 1
+    assert history[0]["sequence"] == sequence
+    assert handler.last_update is not None


### PR DESCRIPTION
This pull request introduces a new, unified UDP networking architecture for the project, centralizing socket management and packet handling for all topside modules. It replaces ad-hoc socket code with reusable helpers, adds robust CRC-32 utilities, and implements new background receivers for control telemetry and Zephyr log streaming. The `BitmaskClient` is refactored to use the new transport and CRC code, and now supports uplink watchdog and status reporting.

**Networking infrastructure and CRC utilities:**
- Added `lib/net_transport.py` with reusable UDP socket, listener, and sender classes, plus a centralized sequence number helper, to standardize all UDP networking across modules. (`lib/net_transport.py`)
- Added `lib/crc.py` implementing IEEE 802.3 CRC-32 with both stateless and streaming interfaces, used by all UDP packet modules for data integrity. (`lib/crc.py`)

**New background receivers:**
- Added `lib/control_telemetry.py` for receiving, parsing, and logging control loop telemetry packets, including setpoint/output/error histories for all axes. (`lib/control_telemetry.py`)
- Added `lib/log_udp_receiver.py` for receiving and storing Zephyr firmware log messages broadcast over UDP, with in-memory buffer and disk logging. (`lib/log_udp_receiver.py`)

**BitmaskClient refactor and uplink reliability:**
- Refactored `lib/bitmask.py` to use the new UDP transport and CRC modules, added a watchdog thread for uplink reliability, status reporting, and integration with the resource monitor for ACK tracking. (`lib/bitmask.py`) [[1]](diffhunk://#diff-0ca8d0e2a3a5cc69759ddebb90782dc45ad4c44acff807e03f431c0157433bcfL2-R11) [[2]](diffhunk://#diff-0ca8d0e2a3a5cc69759ddebb90782dc45ad4c44acff807e03f431c0157433bcfL38-R88) [[3]](diffhunk://#diff-0ca8d0e2a3a5cc69759ddebb90782dc45ad4c44acff807e03f431c0157433bcfR100-R117) [[4]](diffhunk://#diff-0ca8d0e2a3a5cc69759ddebb90782dc45ad4c44acff807e03f431c0157433bcfL90-R173)

**Integration and shutdown handling:**
- Updated `app.py` to initialize and cleanly shut down all new background receivers, and to connect the bitmask client with the resource monitor for ACK tracking. (`app.py`) [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R10-R12) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R81-R90) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R108-R113)…iders

- Add control loop telemetry receiver (port 5005) with history and charts
- Add Zephyr log stream receiver (port 5006) for live MCU logs
- Add setpoint override client (port 5007) for attitude hold experiments
- Add shared CRC-32 and UDP transport modules
- Wire up attitude setpoint override card with send/clear handlers
- Fix setpoint override CRC byte order (big-endian to little-endian)
- Change debug sliders to send raw joystick input via bitmask (port 12345) instead of setpoint overrides (port 5007)
- Clear endpoint now resets both bitmask and setpoint override paths