### PR TITLE
add launcher scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ uv sync --frozen
 uv run python app.py
 ```
 
+**One-command launch**
+```bash
+./run.sh
+```
+
+On Windows, run:
+```powershell
+.\run.ps1
+```
+
+To leave the launcher terminal free, use `./run.sh --new-terminal` or `.\run.ps1 -NewTerminal`.
+
 **Run tests**
 ```bash
 uv run --frozen --group dev pytest

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,79 @@
+param(
+    [switch]$NewTerminal
+)
+
+$ErrorActionPreference = "Stop"
+
+$RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location -LiteralPath $RootDir
+
+function Test-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Add-UvToPath {
+    $paths = @(
+        Join-Path $env:USERPROFILE ".local\bin"
+        Join-Path $env:USERPROFILE ".cargo\bin"
+    )
+
+    foreach ($path in $paths) {
+        if ((Test-Path -LiteralPath $path) -and ($env:Path -notlike "*$path*")) {
+            $env:Path = "$path;$env:Path"
+        }
+    }
+}
+
+function Install-Uv {
+    if (Test-Command uv) {
+        return
+    }
+
+    Write-Host "Installing uv..."
+    powershell -ExecutionPolicy Bypass -NoProfile -Command "irm https://astral.sh/uv/install.ps1 | iex"
+    Add-UvToPath
+
+    if (-not (Test-Command uv)) {
+        throw "uv was installed, but it is not on PATH. Add %USERPROFILE%\.local\bin to PATH and try again."
+    }
+}
+
+function Ensure-Environment {
+    Install-Uv
+
+    uv python find 3.12 *> $null
+    if ($LASTEXITCODE -ne 0) {
+        uv python install 3.12
+    }
+
+    if (-not (Test-Path -LiteralPath ".venv" -PathType Container)) {
+        uv venv --python 3.12 .venv
+    }
+
+    uv sync --frozen --no-default-groups --inexact
+}
+
+function Start-AppInNewTerminal {
+    $shell = if (Test-Command pwsh) { "pwsh" } else { "powershell" }
+    $escapedRoot = $RootDir.Replace("'", "''")
+    $python = Join-Path $RootDir ".venv\Scripts\python.exe"
+    $escapedPython = $python.Replace("'", "''")
+    $command = "Set-Location -LiteralPath '$escapedRoot'; & '$escapedPython' app.py"
+
+    Start-Process $shell -ArgumentList @(
+        "-NoExit",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        $command
+    )
+}
+
+Ensure-Environment
+
+if ($NewTerminal) {
+    Start-AppInNewTerminal
+} else {
+    & ".venv\Scripts\python.exe" app.py
+}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+detect_linux_distro() {
+    if [[ ! -r /etc/os-release ]]; then
+        echo "unknown"
+        return
+    fi
+
+    # shellcheck disable=SC1091
+    source /etc/os-release
+    local distro="${ID:-unknown}"
+    local like="${ID_LIKE:-}"
+
+    case " $distro $like " in
+        *" ubuntu "*|*" debian "*)
+            echo "ubuntu"
+            ;;
+        *" fedora "*|*" rhel "*|*" centos "*)
+            echo "fedora"
+            ;;
+        *" arch "*)
+            echo "arch"
+            ;;
+        *)
+            echo "$distro"
+            ;;
+    esac
+}
+
+missing_fetcher_help() {
+    local distro="$1"
+
+    echo "uv is not installed, and neither curl nor wget is available."
+    case "$distro" in
+        ubuntu)
+            echo "Install curl with: sudo apt install curl"
+            ;;
+        fedora)
+            echo "Install curl with: sudo dnf install curl"
+            ;;
+        arch)
+            echo "Install curl with: sudo pacman -S curl"
+            ;;
+        *)
+            echo "Install curl or wget, then run this script again."
+            ;;
+    esac
+}
+
+install_uv() {
+    if command_exists uv; then
+        return
+    fi
+
+    local platform
+    platform="$(uname -s)"
+
+    if [[ "$platform" == "Linux" ]]; then
+        local distro
+        distro="$(detect_linux_distro)"
+        echo "Installing uv for Linux (${distro})..."
+    else
+        echo "Installing uv for ${platform}..."
+    fi
+
+    if command_exists curl; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    elif command_exists wget; then
+        wget -qO- https://astral.sh/uv/install.sh | sh
+    else
+        missing_fetcher_help "${distro:-unknown}"
+        exit 1
+    fi
+
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+
+    if ! command_exists uv; then
+        echo "uv was installed, but it is not on PATH. Add ~/.local/bin to PATH and try again."
+        exit 1
+    fi
+}
+
+ensure_environment() {
+    install_uv
+
+    if ! uv python find 3.12 >/dev/null 2>&1; then
+        uv python install 3.12
+    fi
+
+    if [[ ! -d .venv ]]; then
+        uv venv --python 3.12 .venv
+    fi
+
+    uv sync --frozen --no-default-groups --inexact
+}
+
+launch_in_new_terminal() {
+    local quoted_root
+    local quoted_python
+    printf -v quoted_root "%q" "$ROOT_DIR"
+    printf -v quoted_python "%q" "${ROOT_DIR}/.venv/bin/python"
+    local command="cd ${quoted_root} && ${quoted_python} app.py"
+
+    if command_exists gnome-terminal; then
+        gnome-terminal -- bash -lc "${command}; exec bash"
+    elif command_exists konsole; then
+        konsole -e bash -lc "${command}; exec bash"
+    elif command_exists xterm; then
+        xterm -e bash -lc "${command}; exec bash"
+    else
+        echo "No supported terminal emulator found; running in this terminal instead."
+        "${ROOT_DIR}/.venv/bin/python" app.py
+    fi
+}
+
+ensure_environment
+
+if [[ "${1:-}" == "--new-terminal" ]]; then
+    launch_in_new_terminal
+else
+    "${ROOT_DIR}/.venv/bin/python" app.py
+fi


### PR DESCRIPTION
## Summary

This is stacked on top of #31, after the uv and Ruff setup.

- adds `run.sh` for Linux/macOS style shells
- adds `run.ps1` for Windows PowerShell
- installs uv if it is missing
- detects Linux distro families for Fedora, Arch, and Ubuntu-style systems when showing setup help
- creates `.venv` with Python 3.12 when needed
- syncs runtime dependencies with uv
- launches `app.py` through the venv Python
- documents the one-command launch path in the README

Both scripts run in the current terminal by default and support opening a separate terminal with `./run.sh --new-terminal` or `.\run.ps1 -NewTerminal`.

## Stack

Base PRs:

- #30: `uv-migration` -> `main`
- #31: `ruff-lint` -> `uv-migration`

This PR: `run-scripts` -> `ruff-lint`

## Validation

- `bash -n run.sh`
- `shellcheck run.sh`
- PowerShell parse check with `[scriptblock]::Create(...)`
- `uv run --frozen --group lint ruff format --check .`
- `uv run --frozen --group lint ruff check .`
- `uv run --frozen --group dev pytest` -> 3 passed