### PR TITLE
fix mcu network defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from lib.control_telemetry import init_control_telemetry
 from lib.controller import Controller
 from lib.json_data_handler import JSONDataHandler
 from lib.log_udp_receiver import init_log_stream
+from lib.net_transport import DEFAULT_ROV_HOST
 from lib.ninedof_receiver import init_imu_receiver
 from lib.resource_receiver import init_resource_receiver
 from lib.setpoint_override import init_setpoint_override
@@ -18,7 +19,7 @@ from routes import register_routes
 app = Flask(__name__, static_folder="static", template_folder="static/templates")
 
 # Start background UDP sender (20 Hz)
-app.config["BITMASK"] = init_bitmask(rate_hz=20.0, host="192.168.1.100", port=12345)
+app.config["BITMASK"] = init_bitmask(rate_hz=20.0, host=DEFAULT_ROV_HOST, port=12345)
 
 # Initialize and start controller handler (60 Hz)
 app.config["CONTROLLER"] = Controller(bitmask_client=app.config["BITMASK"], rate_hz=60.0)
@@ -44,6 +45,7 @@ send_axis_config(
     imu_axes=_saved_axes,
     accel_axes=_saved_accel_axes,
     offset=_saved_offset,
+    host=DEFAULT_ROV_HOST,
 )
 
 # Initialize RPi camera stream receiver.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -29,9 +29,9 @@ The Topside PC must be on the **same subnet as the onboard device**, otherwise n
 
 | Role            | Address              |
 |-----------------|----------------------|
-| Onboard device  | `192.168.1.100`      |
+| Onboard device  | `10.77.0.2`          |
 | IP camera       | `192.168.1.168`      |
-| Topside PC      | any unused address in `192.168.1.0/24`, e.g. `192.168.1.10` |
+| Topside PC      | `10.77.0.1/24` on the MCU Ethernet adapter |
 
 ### Setting a static IP on Windows
 
@@ -39,13 +39,15 @@ The Topside PC must be on the **same subnet as the onboard device**, otherwise n
 2. Click the active adapter (the one connected to the device, usually **Ethernet**).
 3. Next to **IP assignment**, click **Edit** → choose **Manual** → toggle **IPv4** on.
 4. Enter:
-   - **IP address:** `192.168.1.10`
+   - **IP address:** `10.77.0.1`
    - **Subnet mask:** `255.255.255.0`
    - **Gateway:** leave blank
    - **DNS:** leave blank
 5. Save.
 
-To verify, open a Command Prompt and run `ping 192.168.1.100`. You should see replies.
+To verify, open a Command Prompt and run `ping 10.77.0.2`. You should see replies.
+
+By default Topside sends MCU traffic to `10.77.0.2`. For a nonstandard setup, set `ROV_HOST` before launching Topside. Broadcast helpers default to `10.77.0.255` and can be overridden with `ROV_BROADCAST`.
 
 ### Ports used
 
@@ -61,6 +63,6 @@ If you have a firewall (Windows Defender or similar), allow inbound UDP on `5002
 
 ## Troubleshooting
 
-- **No video / no telemetry** — verify the static IP, then `ping 192.168.1.100`. If the ping fails, the network is the problem, not the app.
+- **No video / no telemetry** — verify the static IP, then `ping 10.77.0.2`. If the ping fails, the network is the problem, not the app.
 - **Settings don't persist between launches** — the config lives at `%LOCALAPPDATA%\Topside\data\config.json`. The installer only writes a starter file if it doesn't exist, so reinstalling won't wipe your settings.
 - **App window closes immediately** — launch from the Start Menu (not by double-clicking inside Program Files). If the console flashes and disappears, run `Topside.exe` from `cmd.exe` to see the error.

--- a/lib/axis_config_sender.py
+++ b/lib/axis_config_sender.py
@@ -20,7 +20,9 @@ import socket
 import struct
 import zlib
 
-NUCLEO_HOST = "192.168.1.100"
+from lib.net_transport import DEFAULT_ROV_HOST
+
+NUCLEO_HOST = DEFAULT_ROV_HOST
 AXIS_CONFIG_PORT = 5004
 
 AXIS_PKT_SET = 0x01

--- a/lib/net_transport.py
+++ b/lib/net_transport.py
@@ -9,14 +9,15 @@ as monotonically increasing sequence counters.
 
 from __future__ import annotations
 
+import os
 import socket
 import threading
 import time
 from dataclasses import dataclass
 from typing import Callable, Optional
 
-DEFAULT_ROV_HOST = "192.168.1.100"
-DEFAULT_BROADCAST = "192.168.1.255"
+DEFAULT_ROV_HOST = os.getenv("ROV_HOST", "10.77.0.2")
+DEFAULT_BROADCAST = os.getenv("ROV_BROADCAST", "10.77.0.255")
 BUFFER_SIZE = 4096
 
 Handler = Callable[[bytes, tuple[str, int]], None]

--- a/lib/pid_config_client.py
+++ b/lib/pid_config_client.py
@@ -13,7 +13,9 @@ import socket
 import struct
 import zlib
 
-MCU_IP = "192.168.1.100"
+from lib.net_transport import DEFAULT_ROV_HOST
+
+MCU_IP = DEFAULT_ROV_HOST
 PID_CONFIG_PORT = 5003
 
 PID_PKT_SET = 0x01
@@ -75,7 +77,7 @@ def _gains_match(sent, received):
     return True
 
 
-def send_pid_gains(gains, timeout=1.0, max_retries=3):
+def send_pid_gains(gains, timeout=1.0, max_retries=3, host=MCU_IP):
     """Send PID gains to MCU, verify the reply matches, retry if lost.
 
     Returns (confirmed_gains, attempts) on success, or (None, attempts) if
@@ -87,7 +89,7 @@ def send_pid_gains(gains, timeout=1.0, max_retries=3):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.settimeout(timeout)
         try:
-            sock.sendto(packet, (MCU_IP, PID_CONFIG_PORT))
+            sock.sendto(packet, (host, PID_CONFIG_PORT))
             data, _ = sock.recvfrom(1024)
             confirmed = _parse_packet(data)
             if confirmed is not None and _gains_match(gains, confirmed):
@@ -101,14 +103,14 @@ def send_pid_gains(gains, timeout=1.0, max_retries=3):
     return None, max_retries
 
 
-def request_pid_gains(timeout=2.0):
+def request_pid_gains(timeout=2.0, host=MCU_IP):
     """Request current PID gains from MCU (REQUEST). Returns gains dict or None."""
     empty = {axis: {"kp": 0.0, "ki": 0.0, "kd": 0.0} for axis in AXES}
     packet = _build_packet(PID_PKT_REQUEST, empty)
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.settimeout(timeout)
     try:
-        sock.sendto(packet, (MCU_IP, PID_CONFIG_PORT))
+        sock.sendto(packet, (host, PID_CONFIG_PORT))
         data, _ = sock.recvfrom(1024)
         return _parse_packet(data)
     except socket.timeout:

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -3,7 +3,8 @@ import struct
 import pytest
 
 import lib.control_telemetry as control_telem
-from lib import bitmask, crc
+import lib.resource_receiver as resource_telem
+from lib import axis_config_sender, bitmask, crc, net_transport, pid_config_client
 
 
 class DummyHandler:
@@ -28,6 +29,14 @@ def test_bitmask_packet_big_endian():
     assert pkt[4:12] == struct.pack("!Q", payload)
     expected_crc = crc.crc32_ieee(struct.pack("!IQ", seq, payload))
     assert pkt[12:] == struct.pack("!I", expected_crc)
+
+
+def test_network_defaults_use_current_mcu_address():
+    assert net_transport.DEFAULT_ROV_HOST == "10.77.0.2"
+    assert net_transport.DEFAULT_BROADCAST == "10.77.0.255"
+    assert bitmask.NUCLEO_HOST == net_transport.DEFAULT_ROV_HOST
+    assert axis_config_sender.NUCLEO_HOST == net_transport.DEFAULT_ROV_HOST
+    assert pid_config_client.MCU_IP == net_transport.DEFAULT_ROV_HOST
 
 
 def test_control_telemetry_history(monkeypatch, tmp_path):
@@ -55,3 +64,42 @@ def test_control_telemetry_history(monkeypatch, tmp_path):
     assert len(history) == 1
     assert history[0]["sequence"] == sequence
     assert handler.last_update is not None
+
+
+def test_resource_telemetry_updates_json_handler(monkeypatch, tmp_path):
+    monkeypatch.setattr(resource_telem, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(resource_telem, "RESOURCE_LOG", tmp_path / "resource_monitor.ndjson")
+    handler = DummyHandler()
+    receiver = resource_telem.ResourceReceiver(data_handler=handler)
+
+    body = struct.pack(
+        ">IIBBHHBBII",
+        7,  # sequence
+        1234,  # uptime_ms
+        4,  # cpu_percent
+        1,  # heap_used_percent
+        502,  # heap_free_kb
+        512,  # heap_total_kb
+        19,  # thread_count
+        0,  # reserved
+        84,  # udp_rx_count
+        0,  # udp_rx_errors
+    )
+    packet = body + struct.pack(">I", crc.crc32_ieee(body))
+
+    receiver._process_packet(packet, ("10.77.0.2", 12346))  # pylint: disable=protected-access
+
+    assert handler.last_update == {
+        "resources": {
+            "sequence": 7,
+            "uptime_ms": 1234,
+            "cpu_percent": 4,
+            "heap_used_percent": 1,
+            "heap_free_kb": 502,
+            "heap_total_kb": 512,
+            "thread_count": 19,
+            "udp_rx_count": 84,
+            "udp_rx_errors": 0,
+        }
+    }
+    assert receiver.get_udp_counters() == (84, 0)


### PR DESCRIPTION
Updates Topside's MCU defaults to the new direct Ethernet address and keeps the control, axis config, and PID clients on the same target.

Related firmware work:
- UiASub/K2-Zephyr#17 changed the MCU workflow to the direct Ethernet setup where the board is expected at `10.77.0.2`.

Validation:
- `uv run --frozen --group dev pytest -p no:cacheprovider`
- `uv run --frozen --group lint ruff check app.py lib tests`
- live MCU check: default Topside bitmask sender used `10.77.0.2` and increased `udp_rx_count` by 42 with zero UDP errors