### PR TITLE
add mcu reset control

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from lib.net_transport import DEFAULT_ROV_HOST
 from lib.ninedof_receiver import init_imu_receiver
 from lib.resource_receiver import init_resource_receiver
 from lib.setpoint_override import init_setpoint_override
+from lib.system_control_client import SystemControlClient
 from routes import register_routes
 
 app = Flask(__name__, static_folder="static", template_folder="static/templates")
@@ -93,6 +94,9 @@ app.config["CONTROL_TELEM"] = init_control_telemetry(port=5005)
 # Start Zephyr log stream receiver (UDP port 5006)
 app.config["LOG_STREAM"] = init_log_stream(port=5006)
 
+# Initialize system control client (UDP port 5008)
+app.config["SYSTEM_CONTROL"] = SystemControlClient()
+
 register_routes(app)
 camera = init_camera()
 
@@ -125,6 +129,9 @@ def _shutdown():
     sp_override = app.config.get("SETPOINT_OVERRIDE")
     if sp_override:
         sp_override.close()
+    system_control = app.config.get("SYSTEM_CONTROL")
+    if system_control:
+        system_control.close()
 
 
 atexit.register(_shutdown)

--- a/lib/system_control_client.py
+++ b/lib/system_control_client.py
@@ -1,0 +1,45 @@
+"""Send system-level control commands to the MCU."""
+
+import struct
+import time
+
+from lib.crc import crc32_ieee
+from lib.net_transport import DEFAULT_ROV_HOST, UdpSender, next_sequence
+
+SYSTEM_CONTROL_PORT = 5008
+RESET_MAGIC = b"RST1"
+
+
+def build_reset_packet(sequence: int) -> bytes:
+    body = RESET_MAGIC + struct.pack("!I", sequence & 0xFFFFFFFF)
+    crc = crc32_ieee(body)
+    return body + struct.pack("!I", crc)
+
+
+class SystemControlClient:
+    def __init__(self, host=DEFAULT_ROV_HOST, port=SYSTEM_CONTROL_PORT):
+        self.host = host
+        self.port = port
+        self._sender = UdpSender(host, port)
+        self._sequence = 0
+        self._last_reset_time = None
+
+    def close(self) -> None:
+        self._sender.close()
+
+    def send_reset(self, repeats: int = 3, delay: float = 0.05) -> dict:
+        sequence = self._sequence
+        packet = build_reset_packet(sequence)
+        for _ in range(max(1, repeats)):
+            self._sender.send(packet)
+            if delay > 0:
+                time.sleep(delay)
+        self._sequence = next_sequence(self._sequence)
+        self._last_reset_time = time.time()
+        return {
+            "sequence": sequence,
+            "host": self.host,
+            "port": self.port,
+            "repeats": max(1, repeats),
+            "last_reset_time": self._last_reset_time,
+        }

--- a/routes.py
+++ b/routes.py
@@ -231,6 +231,17 @@ def register_routes(app):
         entries = log_stream.get_recent(limit) if log_stream else []
         return jsonify({"ok": True, "logs": entries})
 
+    @app.route("/api/system/reset", methods=["POST"])
+    def system_reset():
+        client = current_app.config.get("SYSTEM_CONTROL")
+        if not client:
+            return jsonify({"ok": False, "error": "System control client unavailable"}), 503
+        try:
+            result = client.send_reset()
+        except Exception as exc:  # pylint: disable=broad-except
+            return jsonify({"ok": False, "error": str(exc)}), 503
+        return jsonify({"ok": True, "reset": result})
+
     @app.route("/api/setpoint/status", methods=["GET"])
     def setpoint_status():
         client = current_app.config.get("SETPOINT_OVERRIDE")

--- a/static/js/debug.js
+++ b/static/js/debug.js
@@ -46,6 +46,8 @@
   const btnAttitudeClear = document.getElementById("btn-attitude-clear");
   const attitudeFeedback = document.getElementById("attitude-feedback");
   const attitudeStatus = document.getElementById("attitude-status");
+  const btnSystemReset = document.getElementById("btn-system-reset");
+  const systemResetStatus = document.getElementById("system-reset-status");
 
   // --- Slider helpers ---
   function getSliderValue(axis) {
@@ -523,6 +525,36 @@
 
   pollIMU();
   setInterval(pollIMU, 200);
+
+  if (btnSystemReset) {
+    btnSystemReset.addEventListener("click", async () => {
+      if (!window.confirm("Restart the MCU now?")) return;
+      systemResetStatus.textContent = "SENDING";
+      systemResetStatus.className = "badge bg-warning text-dark";
+      btnSystemReset.disabled = true;
+      try {
+        const res = await fetch("/api/system/reset", { method: "POST" });
+        const data = await res.json();
+        if (data.ok) {
+          systemResetStatus.textContent = "RESET SENT";
+          systemResetStatus.className = "badge bg-success";
+        } else {
+          systemResetStatus.textContent = data.error || "FAILED";
+          systemResetStatus.className = "badge bg-danger";
+        }
+      } catch (e) {
+        systemResetStatus.textContent = "ERROR";
+        systemResetStatus.className = "badge bg-danger";
+        console.error("MCU reset failed:", e);
+      } finally {
+        setTimeout(() => {
+          systemResetStatus.textContent = "READY";
+          systemResetStatus.className = "badge bg-secondary";
+          btnSystemReset.disabled = false;
+        }, 3000);
+      }
+    });
+  }
 
   // IMU Offset from Mass Center
   const offsetX = document.getElementById("offset-x");

--- a/static/templates/debug.html
+++ b/static/templates/debug.html
@@ -101,6 +101,24 @@
   </div>
 </div>
 
+<!-- System Controls -->
+<div class="row g-4 mt-1">
+  <div class="col-12">
+    <div class="card custom-card">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h5 class="card-title mb-0">System Controls</h5>
+          <span id="system-reset-status" class="badge bg-secondary">READY</span>
+        </div>
+        <p class="text-muted small mb-3">
+          Request a cold restart of the MCU. Thrusters will stop while the controller reboots and reconnects.
+        </p>
+        <button id="btn-system-reset" class="btn btn-sm btn-outline-danger">Restart MCU</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Accelerometer Axis Mapping -->
 <div class="row g-4 mt-1">
   <div class="col-12">

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -4,7 +4,7 @@ import pytest
 
 import lib.control_telemetry as control_telem
 import lib.resource_receiver as resource_telem
-from lib import axis_config_sender, bitmask, crc, net_transport, pid_config_client
+from lib import axis_config_sender, bitmask, crc, net_transport, pid_config_client, system_control_client
 
 
 class DummyHandler:
@@ -29,6 +29,14 @@ def test_bitmask_packet_big_endian():
     assert pkt[4:12] == struct.pack("!Q", payload)
     expected_crc = crc.crc32_ieee(struct.pack("!IQ", seq, payload))
     assert pkt[12:] == struct.pack("!I", expected_crc)
+
+
+def test_system_reset_packet_crc():
+    pkt = system_control_client.build_reset_packet(0x01020304)
+    assert pkt[:4] == b"RST1"
+    assert pkt[4:8] == struct.pack("!I", 0x01020304)
+    expected_crc = crc.crc32_ieee(pkt[:8])
+    assert pkt[8:] == struct.pack("!I", expected_crc)
 
 
 def test_network_defaults_use_current_mcu_address():


### PR DESCRIPTION
## What changed

- Adds a system control UDP client for MCU reset packets on port 5008.
- Adds a `/api/system/reset` endpoint and a debug-page button to restart the MCU.
- Adds protocol coverage for the reset packet CRC.

## Why

This gives operators a simple debug UI path to recover the MCU without power cycling the vehicle or manually sending packets.

## Paired PR

- Firmware PR: https://github.com/UiASub/K2-Zephyr/pull/21

## Validation

- `uv run --frozen --group lint ruff format --check .`
- `uv run --frozen --group lint ruff check .`
- `uv run --frozen pytest`