### PR TITLE
add ethernet setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ On Windows, run:
 
 To leave the launcher terminal free, use `./run.sh --new-terminal` or `.\run.ps1 -NewTerminal`.
 
+**Set up MCU Ethernet**
+```bash
+./tools/k2-ethernet.sh up
+```
+
+On Windows, run from an Administrator PowerShell:
+```powershell
+.\tools\k2-ethernet.ps1 up
+```
+
+See [docs/SETUP.md](docs/SETUP.md) for manual network setup and troubleshooting.
+
 **Run tests**
 ```bash
 uv run --frozen --group dev pytest

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -33,7 +33,35 @@ The Topside PC must be on the **same subnet as the onboard device**, otherwise n
 | IP camera       | `192.168.1.168`      |
 | Topside PC      | `10.77.0.1/24` on the MCU Ethernet adapter |
 
-### Setting a static IP on Windows
+### Automated MCU Ethernet setup
+
+Topside includes helper scripts that configure the selected Ethernet adapter as `10.77.0.1/24`, then try to ping the MCU at `10.77.0.2`. If the ping fails, the scripts warn and continue so setup can still finish before the cable or MCU is connected.
+
+On Fedora/Linux with NetworkManager:
+
+```bash
+./tools/k2-ethernet.sh up
+```
+
+On Windows, run from an Administrator PowerShell:
+
+```powershell
+.\tools\k2-ethernet.ps1 up
+```
+
+Both scripts show a menu of Ethernet adapters and mark the most likely USB Ethernet adapter as recommended. Use `status` to inspect the current setup and `down` to remove the direct-link configuration:
+
+```bash
+./tools/k2-ethernet.sh status
+./tools/k2-ethernet.sh down
+```
+
+```powershell
+.\tools\k2-ethernet.ps1 status
+.\tools\k2-ethernet.ps1 down
+```
+
+### Manual static IP on Windows
 
 1. Open **Settings → Network & internet**.
 2. Click the active adapter (the one connected to the device, usually **Ethernet**).

--- a/tools/k2-ethernet.ps1
+++ b/tools/k2-ethernet.ps1
@@ -7,6 +7,8 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$StateDir = Join-Path ([Environment]::GetFolderPath("LocalApplicationData")) "Topside"
+$StatePath = Join-Path $StateDir "k2-ethernet-state.json"
 
 function Test-IsAdmin {
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
@@ -79,6 +81,75 @@ function Select-K2Adapter {
     return $adapters[$index].Adapter
 }
 
+function Get-AdapterKey {
+    param($Adapter)
+
+    if ($Adapter.InterfaceGuid) {
+        return $Adapter.InterfaceGuid.ToString()
+    }
+    if ($Adapter.PnPDeviceID) {
+        return $Adapter.PnPDeviceID
+    }
+    return "$($Adapter.Name)|$($Adapter.MacAddress)"
+}
+
+function Get-K2State {
+    if (-not (Test-Path $StatePath)) {
+        return $null
+    }
+
+    try {
+        return Get-Content -Raw -Path $StatePath | ConvertFrom-Json
+    } catch {
+        Write-Warning "Could not read saved K2 Ethernet state from $StatePath."
+        return $null
+    }
+}
+
+function Save-K2State {
+    param($Adapter)
+
+    $adapterKey = Get-AdapterKey $Adapter
+    $existing = Get-K2State
+    if ($existing -and $existing.AdapterKey -eq $adapterKey) {
+        return
+    }
+
+    $ipInterface = Get-NetIPInterface -InterfaceIndex $Adapter.ifIndex -AddressFamily IPv4 -ErrorAction Stop
+    New-Item -ItemType Directory -Force -Path $StateDir | Out-Null
+    [pscustomobject]@{
+        AdapterKey = $adapterKey
+        Name = $Adapter.Name
+        Dhcp = $ipInterface.Dhcp.ToString()
+        SavedAt = (Get-Date).ToString("o")
+    } | ConvertTo-Json | Set-Content -Encoding UTF8 -Path $StatePath
+}
+
+function Restore-K2State {
+    param($Adapter)
+
+    $state = Get-K2State
+    if (-not $state) {
+        Write-Warning "No saved K2 Ethernet state found. Leaving DHCP/static configuration unchanged."
+        return
+    }
+
+    $adapterKey = Get-AdapterKey $Adapter
+    if ($state.AdapterKey -ne $adapterKey) {
+        Write-Warning "Saved K2 Ethernet state is for '$($state.Name)', not '$($Adapter.Name)'. Leaving DHCP/static configuration unchanged."
+        return
+    }
+
+    if ($state.Dhcp -eq "Enabled") {
+        Set-NetIPInterface -InterfaceIndex $Adapter.ifIndex -AddressFamily IPv4 -Dhcp Enabled | Out-Null
+        Write-Host "Restored DHCP on $($Adapter.Name)."
+    } else {
+        Write-Host "Leaving DHCP disabled on $($Adapter.Name), matching the state before K2 setup."
+    }
+
+    Remove-Item -Path $StatePath -ErrorAction SilentlyContinue
+}
+
 function Remove-K2Address {
     param($Adapter)
 
@@ -94,6 +165,7 @@ function Set-K2Link {
 
     $adapter = Select-K2Adapter
 
+    Save-K2State $adapter
     Remove-K2Address $adapter
     Set-NetIPInterface -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4 -Dhcp Disabled | Out-Null
     New-NetIPAddress -InterfaceIndex $adapter.ifIndex -IPAddress $HostIp -PrefixLength $PrefixLength | Out-Null
@@ -110,8 +182,8 @@ function Clear-K2Link {
 
     $adapter = Select-K2Adapter
     Remove-K2Address $adapter
-    Set-NetIPInterface -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4 -Dhcp Enabled | Out-Null
     Write-Host "Removed $HostIp from $($adapter.Name)."
+    Restore-K2State $adapter
 }
 
 function Show-K2Status {

--- a/tools/k2-ethernet.ps1
+++ b/tools/k2-ethernet.ps1
@@ -1,0 +1,147 @@
+param(
+    [ValidateSet("up", "down", "status")]
+    [string]$Action = "up",
+    [string]$HostIp = "10.77.0.1",
+    [string]$McuIp = "10.77.0.2",
+    [int]$PrefixLength = 24
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-IsAdmin {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-AdapterScore {
+    param($Adapter)
+
+    $score = 0
+    $description = "$($Adapter.InterfaceDescription) $($Adapter.Name)"
+
+    if ($Adapter.HardwareInterface) { $score += 20 }
+    if ($Adapter.Status -eq "Up") { $score += 20 }
+    if ($description -match "USB|CDC|Realtek|QinHeng|ASIX|Ethernet Adapter") { $score += 100 }
+    if ($description -match "Wi-Fi|Wireless|Bluetooth|Loopback|Virtual|Hyper-V|VPN|TAP|Docker") { $score -= 200 }
+
+    try {
+        $pnp = Get-PnpDevice -InstanceId $Adapter.PnPDeviceID -ErrorAction Stop
+        if ($pnp.InstanceId -match "^USB\\") { $score += 80 }
+        if ($pnp.FriendlyName -match "USB|Ethernet") { $score += 20 }
+    } catch {
+        # PnP metadata is helpful but not required.
+    }
+
+    return $score
+}
+
+function Select-K2Adapter {
+    $adapters = Get-NetAdapter -Physical |
+        Where-Object {
+            $_.InterfaceDescription -notmatch "Wi-Fi|Wireless|Bluetooth" -and
+            $_.Status -ne "Disabled"
+        } |
+        ForEach-Object {
+            [pscustomobject]@{
+                Adapter = $_
+                Score = Get-AdapterScore $_
+            }
+        } |
+        Where-Object { $_.Score -gt -100 } |
+        Sort-Object Score -Descending
+
+    if (-not $adapters) {
+        throw "No physical Ethernet adapters found."
+    }
+
+    Write-Host "Select Ethernet interface for K2 direct link:"
+    for ($i = 0; $i -lt $adapters.Count; $i++) {
+        $adapter = $adapters[$i].Adapter
+        $suffix = if ($i -eq 0) { " (recommended)" } else { "" }
+        Write-Host ("  {0}) {1} [{2}] {3}{4}" -f ($i + 1), $adapter.Name, $adapter.Status, $adapter.InterfaceDescription, $suffix)
+    }
+
+    $choice = Read-Host "Interface [1]"
+    if ([string]::IsNullOrWhiteSpace($choice)) {
+        $choice = "1"
+    }
+    $parsedChoice = 0
+    if (-not [int]::TryParse($choice, [ref]$parsedChoice)) {
+        throw "Invalid selection: $choice"
+    }
+
+    $index = $parsedChoice - 1
+    if ($index -lt 0 -or $index -ge $adapters.Count) {
+        throw "Invalid selection: $choice"
+    }
+
+    return $adapters[$index].Adapter
+}
+
+function Remove-K2Address {
+    param($Adapter)
+
+    Get-NetIPAddress -InterfaceIndex $Adapter.ifIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+        Where-Object { $_.IPAddress -eq $HostIp } |
+        Remove-NetIPAddress -Confirm:$false -ErrorAction SilentlyContinue
+}
+
+function Set-K2Link {
+    if (-not (Test-IsAdmin)) {
+        throw "Run this script from an Administrator PowerShell session."
+    }
+
+    $adapter = Select-K2Adapter
+
+    Remove-K2Address $adapter
+    Set-NetIPInterface -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4 -Dhcp Disabled | Out-Null
+    New-NetIPAddress -InterfaceIndex $adapter.ifIndex -IPAddress $HostIp -PrefixLength $PrefixLength | Out-Null
+
+    Write-Host "Configured $($adapter.Name) as $HostIp/$PrefixLength for K2 direct link."
+    Test-K2Ping
+    Test-Mcumgr
+}
+
+function Clear-K2Link {
+    if (-not (Test-IsAdmin)) {
+        throw "Run this script from an Administrator PowerShell session."
+    }
+
+    $adapter = Select-K2Adapter
+    Remove-K2Address $adapter
+    Set-NetIPInterface -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4 -Dhcp Enabled | Out-Null
+    Write-Host "Removed $HostIp from $($adapter.Name)."
+}
+
+function Show-K2Status {
+    Get-NetAdapter | Format-Table -AutoSize Name, Status, LinkSpeed, InterfaceDescription
+    Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+        Where-Object { $_.IPAddress -eq $HostIp -or $_.IPAddress -eq $McuIp } |
+        Format-Table -AutoSize InterfaceAlias, IPAddress, PrefixLength
+    Test-Mcumgr
+}
+
+function Test-K2Ping {
+    Write-Host "Checking MCU at $McuIp..."
+    if (Test-Connection -ComputerName $McuIp -Count 2 -Quiet) {
+        Write-Host "MCU responded at $McuIp."
+    } else {
+        Write-Warning "MCU did not respond to ping at $McuIp. The Ethernet cable may be disconnected, the MCU may be off, or ICMP may be unavailable."
+    }
+}
+
+function Test-Mcumgr {
+    if (Get-Command mcumgr -ErrorAction SilentlyContinue) {
+        mcumgr version
+        return
+    }
+
+    Write-Warning "mcumgr is not installed or not on PATH. Install Go, run 'go install github.com/apache/mynewt-mcumgr-cli/mcumgr@latest', and make sure `$env:USERPROFILE\go\bin is on PATH."
+}
+
+switch ($Action) {
+    "up" { Set-K2Link }
+    "down" { Clear-K2Link }
+    "status" { Show-K2Status }
+}

--- a/tools/k2-ethernet.sh
+++ b/tools/k2-ethernet.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST_IP="${HOST_IP:-10.77.0.1}"
+MCU_IP="${MCU_IP:-10.77.0.2}"
+PREFIX="${PREFIX:-24}"
+CON_PREFIX="${CON_PREFIX:-k2-direct}"
+ACTION="${1:-up}"
+
+usage() {
+    echo "Usage: $0 [up|down|status]"
+}
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+run_nmcli() {
+    if nmcli "$@"; then
+        return 0
+    fi
+
+    if [[ "${EUID}" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+        sudo nmcli "$@"
+        return $?
+    fi
+
+    return 1
+}
+
+score_iface() {
+    local iface="$1"
+    local state="$2"
+    local score=0
+    local props=""
+    local devpath=""
+
+    props="$(udevadm info -q property -p "/sys/class/net/${iface}" 2>/dev/null || true)"
+    devpath="$(readlink -f "/sys/class/net/${iface}/device" 2>/dev/null || true)"
+
+    if grep -q '^ID_BUS=usb$' <<<"$props"; then
+        score=$((score + 100))
+    fi
+    if [[ "$devpath" == *"/usb"* ]]; then
+        score=$((score + 80))
+    fi
+    if [[ "$state" == "connected" || "$state" == "connecting"* ]]; then
+        score=$((score + 20))
+    fi
+    if [[ "$(cat "/sys/class/net/${iface}/operstate" 2>/dev/null || true)" == "up" ]]; then
+        score=$((score + 10))
+    fi
+    if [[ "$iface" == docker* || "$iface" == br-* || "$iface" == virbr* ]]; then
+        score=$((score - 200))
+    fi
+
+    echo "$score"
+}
+
+describe_iface() {
+    local iface="$1"
+    local props=""
+    props="$(udevadm info -q property -p "/sys/class/net/${iface}" 2>/dev/null || true)"
+
+    local vendor model driver
+    vendor="$(grep '^ID_VENDOR_FROM_DATABASE=' <<<"$props" | cut -d= -f2- || true)"
+    [[ -z "$vendor" ]] && vendor="$(grep '^ID_VENDOR=' <<<"$props" | cut -d= -f2- || true)"
+    model="$(grep '^ID_MODEL=' <<<"$props" | cut -d= -f2- | tr '_' ' ' || true)"
+    driver="$(grep '^ID_NET_DRIVER=' <<<"$props" | cut -d= -f2- || true)"
+
+    printf "%s %s %s" "$vendor" "$model" "$driver" | xargs
+}
+
+select_iface() {
+    local rows=()
+    local line iface type state score desc
+
+    while IFS=: read -r iface type state _; do
+        [[ "$type" == "ethernet" ]] || continue
+        score="$(score_iface "$iface" "$state")"
+        (( score > -100 )) || continue
+        desc="$(describe_iface "$iface")"
+        rows+=("${score}:${iface}:${state}:${desc}")
+    done < <(nmcli -t -f DEVICE,TYPE,STATE device status)
+
+    if (( ${#rows[@]} == 0 )); then
+        echo "No Ethernet interfaces found." >&2
+        exit 1
+    fi
+
+    mapfile -t rows < <(printf '%s\n' "${rows[@]}" | sort -rn)
+
+    echo "Select Ethernet interface for K2 direct link:" >&2
+    local idx=1
+    for line in "${rows[@]}"; do
+        IFS=: read -r score iface state desc <<<"$line"
+        if (( idx == 1 )); then
+            printf "  %d) %s [%s] %s (recommended)\n" "$idx" "$iface" "$state" "$desc" >&2
+        else
+            printf "  %d) %s [%s] %s\n" "$idx" "$iface" "$state" "$desc" >&2
+        fi
+        idx=$((idx + 1))
+    done
+
+    local choice
+    read -r -p "Interface [1]: " choice
+    choice="${choice:-1}"
+    if ! [[ "$choice" =~ ^[0-9]+$ ]] || (( choice < 1 || choice > ${#rows[@]} )); then
+        echo "Invalid selection: $choice" >&2
+        exit 1
+    fi
+
+    IFS=: read -r _ iface _ _ <<<"${rows[$((choice - 1))]}"
+    echo "$iface"
+}
+
+ping_mcu() {
+    echo "Checking MCU at ${MCU_IP}..."
+    if ping -c 2 -W 1 "$MCU_IP" >/dev/null 2>&1; then
+        echo "MCU responded at ${MCU_IP}."
+    else
+        echo "Warning: MCU did not respond to ping at ${MCU_IP}." >&2
+        echo "The Ethernet cable may be disconnected, the MCU may be off, or ICMP may be unavailable." >&2
+    fi
+}
+
+check_mcumgr() {
+    if command -v mcumgr >/dev/null 2>&1; then
+        return
+    fi
+
+    echo "Warning: mcumgr is not installed or not on PATH." >&2
+    echo "Install it with:" >&2
+    echo "  sudo dnf install golang" >&2
+    echo "  go install github.com/apache/mynewt-mcumgr-cli/mcumgr@latest" >&2
+    echo "Then make sure ~/go/bin is on PATH." >&2
+}
+
+status_all() {
+    nmcli device status
+    echo
+    nmcli connection show --active
+    echo
+    if command -v mcumgr >/dev/null 2>&1; then
+        mcumgr version
+    else
+        check_mcumgr
+    fi
+}
+
+up() {
+    local iface="$1"
+    local conn="${CON_PREFIX}-${iface}"
+
+    if ! nmcli -t -f NAME connection show | grep -Fxq "$conn"; then
+        run_nmcli connection add type ethernet ifname "$iface" con-name "$conn"
+    fi
+
+    run_nmcli connection modify "$conn" \
+        connection.interface-name "$iface" \
+        connection.autoconnect no \
+        ipv4.method manual \
+        ipv4.addresses "${HOST_IP}/${PREFIX}" \
+        ipv4.gateway "" \
+        ipv4.dns "" \
+        ipv4.never-default yes \
+        ipv6.method disabled
+
+    run_nmcli connection up "$conn" ifname "$iface"
+
+    echo "Configured ${iface} as ${HOST_IP}/${PREFIX} for K2 direct link."
+    ping_mcu
+    check_mcumgr
+}
+
+down() {
+    local iface="$1"
+    local conn="${CON_PREFIX}-${iface}"
+
+    if nmcli -t -f NAME connection show | grep -Fxq "$conn"; then
+        run_nmcli connection down "$conn" || true
+        echo "Disconnected ${conn}."
+    else
+        echo "No ${conn} connection exists."
+    fi
+}
+
+require_cmd nmcli
+require_cmd udevadm
+
+case "$ACTION" in
+    up)
+        up "$(select_iface)"
+        ;;
+    down)
+        down "$(select_iface)"
+        ;;
+    status)
+        status_all
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        usage >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Adds the K2 direct-link Ethernet setup scripts to Topside so operators can configure the MCU Ethernet adapter from the app repo.

Changes:
- copy the Fedora/Linux NetworkManager helper from K2-Zephyr as `tools/k2-ethernet.sh`
- copy the Windows Administrator PowerShell helper as `tools/k2-ethernet.ps1`
- document the helper commands in the README and setup guide
- keep the manual Windows static-IP steps as a fallback

The scripts select an Ethernet adapter from a menu, recommend the likely USB Ethernet adapter, configure the PC as `10.77.0.1/24`, and try to ping the MCU at `10.77.0.2` without failing setup if the ping does not respond.

Validated:
- `bash -n tools/k2-ethernet.sh`
- PowerShell parser check for `tools/k2-ethernet.ps1`
- `git diff --check`
- `uv run --frozen --group dev pytest` (`6 passed`)

This branch is based on `main` and intentionally does not include the separate MCU port docs branch.
